### PR TITLE
Cleanup and docs polish; split Simplified Chinese README

### DIFF
--- a/COOKIE_HELP.md
+++ b/COOKIE_HELP.md
@@ -1,6 +1,7 @@
-# iCloud China Cookie Setup
+# iCloud Cookie Setup
 
-1. Open `https://www.icloud.com.cn/settings/` and log in.
+1. Open `https://www.icloud.com/settings/` and log in
+   (use `https://www.icloud.com.cn/settings/` for iCloud China).
 2. Press `F12`.
 3. Open the `Network` tab.
 4. Refresh the page.

--- a/README.md
+++ b/README.md
@@ -11,44 +11,37 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/rtunazzz/hidemyemail-generator/blob/main/LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-2ea44f"></a>
+  <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-2ea44f"></a>
   <img alt="Python 3.12+" src="https://img.shields.io/badge/python-3.12%2B-3776ab?logo=python&logoColor=white">
-  <img alt="uv ready" src="https://img.shields.io/badge/uv-ready-5c4ee5">
-  <img alt="Windows launcher" src="https://img.shields.io/badge/windows-launcher-0078d4?logo=windows&logoColor=white">
-  <img alt="iCloud China" src="https://img.shields.io/badge/iCloud-China%20ready-f57c00">
-  <img alt="Local inbox" src="https://img.shields.io/badge/local-inbox-0f766e">
+  <a href="https://github.com/rtunazzz/hidemyemail-generator/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/rtunazzz/hidemyemail-generator?logo=github"></a>
+  <a href="https://github.com/rtunazzz/hidemyemail-generator/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/rtunazzz/hidemyemail-generator/total?logo=github"></a>
 </p>
 
 <p align="center">
-  <a href="#english">English</a>
+  <strong>English</strong>
   ·
-  <a href="#简体中文">简体中文</a>
-  ·
-  <a href="https://github.com/rtunazzz/hidemyemail-generator">Upstream</a>
+  <a href="./README.zh-CN.md">简体中文</a>
 </p>
 
 > You need an active iCloud+ subscription to generate Hide My Email addresses.
 
-<a id="english"></a>
-
 ## Overview
 
 HideMyEmail Generator is a local command-line utility for Apple's iCloud Hide My
-Email service. It can generate new addresses, list active or inactive addresses,
-and validate the currently saved iCloud cookie.
+Email service. It generates and reserves new addresses, lists active or inactive
+ones, and inspects the account behind the currently saved iCloud cookie.
 
-This version focuses on a smoother Windows and iCloud China workflow:
+Alongside the basics it provides:
 
 - region-aware iCloud API targeting for `global` and `china`;
 - automatic iCloud partition detection;
-- one-click Windows launcher;
-- bilingual English/Simplified Chinese launcher and CLI output;
-- account-aware cookie management;
-- browser-assisted cookie capture for iCloud China;
-- local IMAP inbox and verification code extraction;
-- local address state management for `unused`, `used`, and `trash`;
+- a one-click Windows launcher;
+- bilingual English / Simplified Chinese launcher and CLI output;
+- account-aware cookie management with browser-assisted capture;
+- a local IMAP inbox with verification-code extraction;
+- local address state management (`unused`, `used`, `trash`);
 - CSV export for addresses and received messages;
-- longer timeout and retry behavior for slower iCloud responses.
+- longer timeouts and automatic retries for slower iCloud responses.
 
 ## Contents
 
@@ -62,10 +55,10 @@ This version focuses on a smoother Windows and iCloud China workflow:
 - [Generated Files](#generated-files)
 - [Troubleshooting](#troubleshooting)
 - [Security and Privacy](#security-and-privacy)
+- [Rate Limits](#rate-limits)
 - [Disclaimer](#disclaimer)
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
-- [简体中文](#简体中文)
 
 ## Highlights
 
@@ -91,13 +84,7 @@ cd hidemyemail-generator
 uv sync --python 3.12
 ```
 
-On Windows, double-click:
-
-```text
-start-hidemyemail.bat
-```
-
-For direct CLI usage:
+On Windows, double-click `start-hidemyemail.bat`. For direct CLI usage:
 
 ```bash
 uv run hidemyemail --help
@@ -140,18 +127,22 @@ Inbox management:
 10. Back
 ```
 
-The launcher defaults to iCloud China:
+The launcher defaults to the `global` region. To target iCloud China, set the
+environment variable before launching:
 
 ```text
---region china
+HIDEMYEMAIL_REGION=china
 ```
 
 ## CLI Reference
 
+Commands default to the `global` region. Add `--region china` (or set
+`HIDEMYEMAIL_REGION=china`) to target iCloud China.
+
 ### Generate
 
 ```bash
-uv run hidemyemail generate --label test --count 1 --cookie-file cookies.txt --region china
+uv run hidemyemail generate --label test --count 1 --cookie-file cookies.txt
 ```
 
 Options:
@@ -163,38 +154,38 @@ Options:
 | `--cookie-file` | Path to the saved cookie file. Defaults to `cookies.txt`. |
 | `--output` | File used to append generated addresses. Defaults to `emails.txt`. |
 | `--no-output-file` | Print results without writing to an output file. |
-| `--region` | `china` or `global`. |
+| `--region` | `global` (default) or `china`. |
 
 ### List
 
 ```bash
-uv run hidemyemail list --active --cookie-file cookies.txt --region china
-uv run hidemyemail list --inactive --cookie-file cookies.txt --region china
+uv run hidemyemail list --active --cookie-file cookies.txt
+uv run hidemyemail list --inactive --cookie-file cookies.txt
 ```
 
 ### Account Check
 
 ```bash
-uv run hidemyemail whoami --cookie-file cookies.txt --region china
+uv run hidemyemail whoami --cookie-file cookies.txt
 ```
 
 Example output:
 
 ```text
 Current iCloud Cookie
-Apple ID       +86 ***********
+Apple ID       user@example.com
 Name           Example User
 DSID           ***********
 Hide My Email  Available
-User Partition 217
-Maildomain     p217-maildomainws.icloud.com.cn
+User Partition 68
+Maildomain     p68-maildomainws.icloud.com
 ```
 
 ### Auto Capture Cookie
 
 ```bash
 uv sync --extra capture
-uv run hidemyemail capture-cookie --cookie-file cookies.txt --region china
+uv run hidemyemail capture-cookie --cookie-file cookies.txt
 ```
 
 ### Local Inbox
@@ -220,7 +211,7 @@ uv run hidemyemail inbox codes --limit 30
 Sync existing iCloud Hide My Email addresses into the local database:
 
 ```bash
-uv run hidemyemail inbox sync-hme --cookie-file cookies.txt --region china
+uv run hidemyemail inbox sync-hme --cookie-file cookies.txt
 ```
 
 Track address state:
@@ -244,8 +235,6 @@ The tool needs an authenticated iCloud browser cookie. Cookies stay local in
 
 ### Automatic Capture
 
-Recommended for iCloud China:
-
 1. Run `start-hidemyemail.bat`.
 2. Choose `4. Manage iCloud cookie`.
 3. Choose `3. Auto capture iCloud cookie`.
@@ -253,11 +242,14 @@ Recommended for iCloud China:
 5. The tool opens iCloud Plus, clicks Hide My Email, captures the app request,
    validates the cookie, and writes `cookies.txt`.
 
-The capture flow listens for this request:
+The capture flow listens for the Hide My Email app request:
 
 ```text
-https://www.icloud.com.cn/applications/hidemyemail/current/zh-cn/index.html?rootDomain=www
+https://www.icloud.com/applications/hidemyemail/current/en-us/index.html?rootDomain=www
 ```
+
+For iCloud China the host is `www.icloud.com.cn` and the locale segment is
+`zh-cn`.
 
 It uses a separate browser profile:
 
@@ -274,14 +266,14 @@ cookies.txt.bak
 
 ### Manual Capture
 
-1. Open `https://www.icloud.com.cn/icloudplus/`.
+1. Open `https://www.icloud.com/icloudplus/` (use `www.icloud.com.cn` for China).
 2. Press `F12`.
 3. Open `Network`.
-4. Click the `隐藏邮件地址` tile.
+4. Click the `Hide My Email` tile (`隐藏邮件地址` on China).
 5. Find the request ending with:
 
    ```text
-   /applications/hidemyemail/current/zh-cn/index.html?rootDomain=www
+   /applications/hidemyemail/current/en-us/index.html?rootDomain=www
    ```
 
 6. Right-click the request and choose `Copy` -> `Copy as cURL`.
@@ -319,7 +311,7 @@ mailbox password.
 | Setting | Values | Notes |
 | --- | --- | --- |
 | `--region` | `china`, `global` | Selects iCloud China or global iCloud endpoints. |
-| `HIDEMYEMAIL_REGION` | `china`, `global` | Optional environment default for CLI commands. |
+| `HIDEMYEMAIL_REGION` | `china`, `global` | Optional default region for the CLI and launcher. Defaults to `global`. |
 | `cookies.txt` | local file | Stores the captured cookie in a Git-ignored file. |
 | `emails.txt` | local file | Stores generated addresses unless `--no-output-file` is used. |
 | `inbox_config.json` | local file | Stores IMAP settings for the receiving mailbox. |
@@ -362,9 +354,9 @@ These files are local-only and ignored by Git:
 
 ## Rate Limits
 
-Apple may rate-limit Hide My Email creation. The upstream project notes an
-observed limit of approximately `5 * number of people in your iCloud family`
-new addresses every 30 minutes, with an observed total cap around 700 addresses.
+Apple may rate-limit Hide My Email creation. Observed limits are roughly
+`5 * number of people in your iCloud family` new addresses every 30 minutes,
+with a total cap around 700 addresses.
 
 ## Disclaimer
 
@@ -374,346 +366,10 @@ trademarks of Apple Inc.
 
 ## Acknowledgements
 
-- Original implementation by [rtuna](https://github.com/rtunazzz).
+- iCloud China support, the Windows launcher, and the local inbox were
+  contributed by [@never-seek](https://github.com/never-seek).
+- Thanks to all other [community contributors](https://github.com/rtunazzz/hidemyemail-generator/graphs/contributors).
 
 ## License
 
 MIT. See [LICENSE](./LICENSE).
-
----
-
-<a id="简体中文"></a>
-
-## 简体中文
-
-HideMyEmail Generator 是一个本地命令行工具，用于生成、保留和管理 Apple
-iCloud「隐藏邮件地址」。
-
-这个版本重点改进 Windows 和 iCloud 中国区体验：一键启动器、中国区接口、账号
-Cookie 识别、自动 Cookie 捕获、本地收件台、验证码提取、分区自动检测，以及更稳定的网络超时和重试。
-
-> 需要有效的 iCloud+ 订阅，才能生成「隐藏邮件地址」。
-
-## 目录
-
-- [功能亮点](#功能亮点)
-- [快速开始](#快速开始)
-- [Windows 启动器](#windows-启动器)
-- [命令行用法](#命令行用法)
-- [Cookie 管理](#cookie-管理)
-- [本地收件台和验证码](#本地收件台和验证码)
-- [配置](#配置)
-- [本地文件](#本地文件)
-- [故障排查](#故障排查)
-- [安全和隐私](#安全和隐私)
-- [免责声明](#免责声明)
-- [致谢](#致谢)
-- [许可证](#许可证)
-
-## 功能亮点
-
-| 功能 | 说明 |
-| --- | --- |
-| 生成地址 | 按指定标签创建并保留 iCloud「隐藏邮件地址」。 |
-| 查看地址 | 查看使用中或已停用的隐藏邮件地址。 |
-| 查看账号 | 显示当前 Cookie 对应的 Apple ID、DSID、用户分区和功能可用性。 |
-| iCloud 中国区 | 使用 `icloud.com.cn` 的 Origin、校验接口和 maildomain 主机。 |
-| 分区检测 | 从捕获请求或账号校验结果推导正确的 `pNNN-maildomainws` 主机。 |
-| Windows 启动器 | 双击即可生成、查看和管理 Cookie。 |
-| 双语界面 | 启动器和 CLI 帮助包含英文和简体中文。 |
-| 自动捕获 Cookie | 打开 iCloud+，点击「隐藏邮件地址」，捕获应用请求并保存 Cookie。 |
-| 本地收件台 | 通过 IMAP 拉取转发邮件，并在本地提取验证码。 |
-| 状态管理 | 将地址标记为 `unused`、`used` 或 `trash`。 |
-| 表格导出 | 导出本地地址和邮件数据，便于表格管理。 |
-
-## 快速开始
-
-```bash
-git clone https://github.com/rtunazzz/hidemyemail-generator.git
-cd hidemyemail-generator
-uv sync --python 3.12
-```
-
-Windows 下双击：
-
-```text
-start-hidemyemail.bat
-```
-
-直接使用命令行：
-
-```bash
-uv run hidemyemail --help
-```
-
-## Windows 启动器
-
-推荐在 Windows 上使用启动器。
-
-```text
-1. Generate emails
-2. List active emails
-3. List inactive emails
-4. Manage iCloud cookie
-5. Local inbox and codes
-6. Exit
-```
-
-Cookie 管理菜单：
-
-```text
-1. Show current cookie account
-2. Replace iCloud cookie
-3. Auto capture iCloud cookie
-4. Back
-```
-
-收件台菜单：
-
-```text
-1. Configure inbox IMAP account
-2. Sync inbox and show verification codes
-3. Show recent verification codes
-4. Show recent inbox messages
-5. List unused local emails
-6. Mark email as used
-7. Move email to trash
-8. Sync iCloud HME addresses to local DB
-9. Export CSV files
-10. Back
-```
-
-启动器默认使用 iCloud 中国区：
-
-```text
---region china
-```
-
-## 命令行用法
-
-### 生成地址
-
-```bash
-uv run hidemyemail generate --label test --count 1 --cookie-file cookies.txt --region china
-```
-
-常用参数：
-
-| 参数 | 说明 |
-| --- | --- |
-| `--label` | 生成地址的标签，必填。 |
-| `--count` | 生成数量，默认 `1`。 |
-| `--cookie-file` | Cookie 文件路径，默认 `cookies.txt`。 |
-| `--output` | 生成结果追加写入文件，默认 `emails.txt`。 |
-| `--no-output-file` | 只打印结果，不写文件。 |
-| `--region` | `china` 或 `global`。 |
-
-### 查看地址
-
-```bash
-uv run hidemyemail list --active --cookie-file cookies.txt --region china
-uv run hidemyemail list --inactive --cookie-file cookies.txt --region china
-```
-
-### 查看当前账号
-
-```bash
-uv run hidemyemail whoami --cookie-file cookies.txt --region china
-```
-
-示例输出：
-
-```text
-Current iCloud Cookie
-Apple ID       +86 ***********
-Name           Example User
-DSID           ***********
-Hide My Email  Available
-User Partition 217
-Maildomain     p217-maildomainws.icloud.com.cn
-```
-
-### 自动捕获 Cookie
-
-```bash
-uv sync --extra capture
-uv run hidemyemail capture-cookie --cookie-file cookies.txt --region china
-```
-
-### 本地收件台
-
-配置接收 iCloud 转发邮件的邮箱：
-
-```bash
-uv run hidemyemail inbox setup
-```
-
-同步最新邮件并显示验证码：
-
-```bash
-uv run hidemyemail inbox sync --limit 100 --show-codes
-```
-
-查看最近验证码：
-
-```bash
-uv run hidemyemail inbox codes --limit 30
-```
-
-同步 iCloud 里已有的隐藏邮箱到本地数据库：
-
-```bash
-uv run hidemyemail inbox sync-hme --cookie-file cookies.txt --region china
-```
-
-管理地址状态：
-
-```bash
-uv run hidemyemail inbox addresses --state unused
-uv run hidemyemail inbox mark example@icloud.com used
-uv run hidemyemail inbox mark example@icloud.com trash
-```
-
-导出 CSV：
-
-```bash
-uv run hidemyemail inbox export
-```
-
-## Cookie 管理
-
-工具需要已登录 iCloud 的浏览器 Cookie。Cookie 只保存在本地 `cookies.txt`，
-并已加入 Git 忽略。
-
-### 自动捕获
-
-推荐用于 iCloud 中国区：
-
-1. 运行 `start-hidemyemail.bat`。
-2. 选择 `4. Manage iCloud cookie`。
-3. 选择 `3. Auto capture iCloud cookie`。
-4. 如果打开的浏览器要求登录，请登录 iCloud。
-5. 工具会打开 iCloud+ 页面，点击「隐藏邮件地址」，捕获应用请求，校验 Cookie，
-   并写入 `cookies.txt`。
-
-自动捕获监听的请求：
-
-```text
-https://www.icloud.com.cn/applications/hidemyemail/current/zh-cn/index.html?rootDomain=www
-```
-
-它使用独立浏览器配置目录：
-
-```text
-.cookie-browser-profile
-```
-
-它不会读取你的日常浏览器配置。如果成功捕获新 Cookie，旧文件会备份为：
-
-```text
-cookies.txt.bak
-```
-
-### 手动捕获
-
-1. 打开 `https://www.icloud.com.cn/icloudplus/`。
-2. 按 `F12`。
-3. 打开 `Network / 网络`。
-4. 点击「隐藏邮件地址」卡片。
-5. 找到以下请求：
-
-   ```text
-   /applications/hidemyemail/current/zh-cn/index.html?rootDomain=www
-   ```
-
-6. 右键请求，选择 `Copy / 复制` -> `Copy as cURL / 复制为 cURL`。
-7. 将整段内容粘贴到 `cookies.txt`。
-
-直接粘贴原始 `Cookie:` 请求头也可以。
-
-## 本地收件台和验证码
-
-本地收件台通过 IMAP 读取接收 iCloud 隐藏邮箱转发邮件的邮箱。它会把邮件元数据、
-匹配到的隐藏邮箱地址和提取出的验证码保存到本地 SQLite 数据库。
-
-它会做：
-
-- 连接你配置的接收邮箱 IMAP；
-- 从指定文件夹同步新邮件；
-- 从邮件标题和正文中提取可能的验证码；
-- 尽量把邮件关联到已知隐藏邮箱；
-- 将隐藏邮箱标记为 `unused`、`used` 或 `trash`；
-- 导出 `addresses.csv` 和 `messages.csv`。
-
-它不会做：
-
-- 不上传邮件或验证码到任何服务器；
-- 不需要公网部署；
-- 不读取你的日常浏览器配置；
-- 不绕过 Apple 或邮箱服务商的频率限制。
-
-很多邮箱服务商要求使用“应用专用密码”，不要直接使用网页登录密码。
-
-## 配置
-
-| 配置 | 值 | 说明 |
-| --- | --- | --- |
-| `--region` | `china`, `global` | 选择 iCloud 中国区或全球区接口。 |
-| `HIDEMYEMAIL_REGION` | `china`, `global` | 可选的命令行默认区域。 |
-| `cookies.txt` | 本地文件 | 保存捕获到的 Cookie。 |
-| `emails.txt` | 本地文件 | 保存生成的隐藏邮件地址。 |
-| `inbox_config.json` | 本地文件 | 保存接收邮箱 IMAP 配置。 |
-| `hidemyemail.db` | 本地文件 | 保存地址、邮件元数据和验证码的 SQLite 数据库。 |
-
-## 本地文件
-
-以下文件只在本地使用，已加入 Git 忽略：
-
-- `cookies.txt`
-- `cookies.txt.bak`
-- `emails.txt`
-- `hidemyemail.db`
-- `hidemyemail.db-*`
-- `inbox_config.json`
-- `exports/`
-- `.cookie-browser-profile/`
-- `.venv/`
-
-## 故障排查
-
-| 现象 | 处理方式 |
-| --- | --- |
-| `Missing X-APPLE-WEBAUTH-USER cookie` | 捕获「隐藏邮件地址」应用请求，不要使用 `feedbackws/reportStats`。 |
-| `Request timed out` | 重试。命令行已经增加超时和重试，但 iCloud 偶尔仍会慢。 |
-| Cookie 对应账号不对 | 用启动器 `4 -> 1` 查看账号，再用 `4 -> 3` 重新捕获。 |
-| 自动捕获无法打开浏览器 | 安装 Microsoft Edge，然后运行 `uv sync --extra capture` 或 `uv run playwright install chromium`。 |
-| 中文在旧控制台里乱码 | 使用启动器；启动器会切换到 UTF-8。 |
-| IMAP 登录失败 | 确认邮箱已开启 IMAP，并按邮箱服务商要求使用应用专用密码。 |
-| 没有识别出验证码 | 用 `hidemyemail inbox messages` 查看标题和正文预览；有些服务商格式不标准。 |
-
-## 安全和隐私
-
-- Cookie 只保存在本地，并已被 Git 忽略。
-- IMAP 配置和本地收件数据只保存在本地，并已被 Git 忽略。
-- 自动捕获使用独立浏览器配置。
-- 项目不会主动收集、上传或分享你的 Cookie、邮件数据或验证码。
-- 不要提交 `cookies.txt`、`cookies.txt.bak`、`emails.txt`、`inbox_config.json`、`hidemyemail.db`、导出目录或浏览器配置目录。
-- 如果 token 或 Cookie 被意外公开，请到对应平台撤销或重新生成。
-
-## 频率限制
-
-Apple 可能限制「隐藏邮件地址」创建频率。上游项目记录的经验值是：
-每 30 分钟大约可创建 `5 * iCloud 家庭人数` 个地址，观察到的总量上限约为 700 个。
-
-## 免责声明
-
-本项目是独立社区工具，不隶属于 Apple Inc.，也未获得 Apple Inc. 的认可或赞助。
-Apple、iCloud 和 Hide My Email 是 Apple Inc. 的商标。
-
-## 致谢
-
-- 原始实现来自 [rtuna](https://github.com/rtunazzz)。
-
-## 许可证
-
-MIT。见 [LICENSE](./LICENSE)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,345 @@
+<h1 align="center">HideMyEmail Generator</h1>
+
+<p align="center">
+  从本地命令行生成、保留和管理 iCloud「隐藏邮件地址」。
+  <br>
+  包含 Windows 启动器、iCloud 中国区支持、本地收件台和自动 Cookie 捕获。
+</p>
+
+<p align="center">
+  <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-2ea44f"></a>
+  <img alt="Python 3.12+" src="https://img.shields.io/badge/python-3.12%2B-3776ab?logo=python&logoColor=white">
+  <a href="https://github.com/rtunazzz/hidemyemail-generator/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/rtunazzz/hidemyemail-generator?logo=github"></a>
+  <a href="https://github.com/rtunazzz/hidemyemail-generator/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/rtunazzz/hidemyemail-generator/total?logo=github"></a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a>
+  ·
+  <strong>简体中文</strong>
+</p>
+
+> 需要有效的 iCloud+ 订阅，才能生成「隐藏邮件地址」。
+
+## 目录
+
+- [功能亮点](#功能亮点)
+- [快速开始](#快速开始)
+- [Windows 启动器](#windows-启动器)
+- [命令行用法](#命令行用法)
+- [Cookie 管理](#cookie-管理)
+- [本地收件台和验证码](#本地收件台和验证码)
+- [配置](#配置)
+- [本地文件](#本地文件)
+- [故障排查](#故障排查)
+- [安全和隐私](#安全和隐私)
+- [频率限制](#频率限制)
+- [免责声明](#免责声明)
+- [致谢](#致谢)
+- [许可证](#许可证)
+
+## 功能亮点
+
+| 功能 | 说明 |
+| --- | --- |
+| 生成地址 | 按指定标签创建并保留 iCloud「隐藏邮件地址」。 |
+| 查看地址 | 查看使用中或已停用的隐藏邮件地址。 |
+| 查看账号 | 显示当前 Cookie 对应的 Apple ID、DSID、用户分区和功能可用性。 |
+| iCloud 中国区 | 使用 `icloud.com.cn` 的 Origin、校验接口和 maildomain 主机。 |
+| 分区检测 | 从捕获请求或账号校验结果推导正确的 `pNNN-maildomainws` 主机。 |
+| Windows 启动器 | 双击即可生成、查看和管理 Cookie。 |
+| 双语界面 | 启动器和 CLI 帮助包含英文和简体中文。 |
+| 自动捕获 Cookie | 打开 iCloud+，点击「隐藏邮件地址」，捕获应用请求并保存 Cookie。 |
+| 本地收件台 | 通过 IMAP 拉取转发邮件，并在本地提取验证码。 |
+| 状态管理 | 将地址标记为 `unused`、`used` 或 `trash`。 |
+| 表格导出 | 导出本地地址和邮件数据，便于表格管理。 |
+
+## 快速开始
+
+```bash
+git clone https://github.com/rtunazzz/hidemyemail-generator.git
+cd hidemyemail-generator
+uv sync --python 3.12
+```
+
+Windows 下双击 `start-hidemyemail.bat`。直接使用命令行：
+
+```bash
+uv run hidemyemail --help
+```
+
+## Windows 启动器
+
+推荐在 Windows 上使用启动器。
+
+```text
+1. Generate emails
+2. List active emails
+3. List inactive emails
+4. Manage iCloud cookie
+5. Local inbox and codes
+6. Exit
+```
+
+Cookie 管理菜单：
+
+```text
+1. Show current cookie account
+2. Replace iCloud cookie
+3. Auto capture iCloud cookie
+4. Back
+```
+
+收件台菜单：
+
+```text
+1. Configure inbox IMAP account
+2. Sync inbox and show verification codes
+3. Show recent verification codes
+4. Show recent inbox messages
+5. List unused local emails
+6. Mark email as used
+7. Move email to trash
+8. Sync iCloud HME addresses to local DB
+9. Export CSV files
+10. Back
+```
+
+启动器默认使用 `global` 区域。如需使用 iCloud 中国区，请在启动前设置环境变量：
+
+```text
+HIDEMYEMAIL_REGION=china
+```
+
+## 命令行用法
+
+命令默认使用 `global` 区域。加上 `--region china`（或设置
+`HIDEMYEMAIL_REGION=china`）即可切换到 iCloud 中国区。
+
+### 生成地址
+
+```bash
+uv run hidemyemail generate --label test --count 1 --cookie-file cookies.txt
+```
+
+常用参数：
+
+| 参数 | 说明 |
+| --- | --- |
+| `--label` | 生成地址的标签，必填。 |
+| `--count` | 生成数量，默认 `1`。 |
+| `--cookie-file` | Cookie 文件路径，默认 `cookies.txt`。 |
+| `--output` | 生成结果追加写入文件，默认 `emails.txt`。 |
+| `--no-output-file` | 只打印结果，不写文件。 |
+| `--region` | `global`（默认）或 `china`。 |
+
+### 查看地址
+
+```bash
+uv run hidemyemail list --active --cookie-file cookies.txt
+uv run hidemyemail list --inactive --cookie-file cookies.txt
+```
+
+### 查看当前账号
+
+```bash
+uv run hidemyemail whoami --cookie-file cookies.txt
+```
+
+示例输出：
+
+```text
+Current iCloud Cookie
+Apple ID       +86 ***********
+Name           Example User
+DSID           ***********
+Hide My Email  Available
+User Partition 217
+Maildomain     p217-maildomainws.icloud.com.cn
+```
+
+### 自动捕获 Cookie
+
+```bash
+uv sync --extra capture
+uv run hidemyemail capture-cookie --cookie-file cookies.txt
+```
+
+### 本地收件台
+
+配置接收 iCloud 转发邮件的邮箱：
+
+```bash
+uv run hidemyemail inbox setup
+```
+
+同步最新邮件并显示验证码：
+
+```bash
+uv run hidemyemail inbox sync --limit 100 --show-codes
+```
+
+查看最近验证码：
+
+```bash
+uv run hidemyemail inbox codes --limit 30
+```
+
+同步 iCloud 里已有的隐藏邮箱到本地数据库：
+
+```bash
+uv run hidemyemail inbox sync-hme --cookie-file cookies.txt
+```
+
+管理地址状态：
+
+```bash
+uv run hidemyemail inbox addresses --state unused
+uv run hidemyemail inbox mark example@icloud.com used
+uv run hidemyemail inbox mark example@icloud.com trash
+```
+
+导出 CSV：
+
+```bash
+uv run hidemyemail inbox export
+```
+
+## Cookie 管理
+
+工具需要已登录 iCloud 的浏览器 Cookie。Cookie 只保存在本地 `cookies.txt`，
+并已加入 Git 忽略。
+
+### 自动捕获
+
+1. 运行 `start-hidemyemail.bat`。
+2. 选择 `4. Manage iCloud cookie`。
+3. 选择 `3. Auto capture iCloud cookie`。
+4. 如果打开的浏览器要求登录，请登录 iCloud。
+5. 工具会打开 iCloud+ 页面，点击「隐藏邮件地址」，捕获应用请求，校验 Cookie，
+   并写入 `cookies.txt`。
+
+自动捕获监听的隐藏邮件地址应用请求：
+
+```text
+https://www.icloud.com/applications/hidemyemail/current/en-us/index.html?rootDomain=www
+```
+
+中国区对应的主机为 `www.icloud.com.cn`，语言段为 `zh-cn`。
+
+它使用独立浏览器配置目录：
+
+```text
+.cookie-browser-profile
+```
+
+它不会读取你的日常浏览器配置。如果成功捕获新 Cookie，旧文件会备份为：
+
+```text
+cookies.txt.bak
+```
+
+### 手动捕获
+
+1. 打开 `https://www.icloud.com/icloudplus/`（中国区使用 `www.icloud.com.cn`）。
+2. 按 `F12`。
+3. 打开 `Network / 网络`。
+4. 点击「Hide My Email / 隐藏邮件地址」卡片。
+5. 找到以下请求：
+
+   ```text
+   /applications/hidemyemail/current/en-us/index.html?rootDomain=www
+   ```
+
+6. 右键请求，选择 `Copy / 复制` -> `Copy as cURL / 复制为 cURL`。
+7. 将整段内容粘贴到 `cookies.txt`。
+
+直接粘贴原始 `Cookie:` 请求头也可以。
+
+## 本地收件台和验证码
+
+本地收件台通过 IMAP 读取接收 iCloud 隐藏邮箱转发邮件的邮箱。它会把邮件元数据、
+匹配到的隐藏邮箱地址和提取出的验证码保存到本地 SQLite 数据库。
+
+它会做：
+
+- 连接你配置的接收邮箱 IMAP；
+- 从指定文件夹同步新邮件；
+- 从邮件标题和正文中提取可能的验证码；
+- 尽量把邮件关联到已知隐藏邮箱；
+- 将隐藏邮箱标记为 `unused`、`used` 或 `trash`；
+- 导出 `addresses.csv` 和 `messages.csv`。
+
+它不会做：
+
+- 不上传邮件或验证码到任何服务器；
+- 不需要公网部署；
+- 不读取你的日常浏览器配置；
+- 不绕过 Apple 或邮箱服务商的频率限制。
+
+很多邮箱服务商要求使用“应用专用密码”，不要直接使用网页登录密码。
+
+## 配置
+
+| 配置 | 值 | 说明 |
+| --- | --- | --- |
+| `--region` | `china`, `global` | 选择 iCloud 中国区或全球区接口。 |
+| `HIDEMYEMAIL_REGION` | `china`, `global` | 命令行和启动器的可选默认区域，默认 `global`。 |
+| `cookies.txt` | 本地文件 | 保存捕获到的 Cookie。 |
+| `emails.txt` | 本地文件 | 保存生成的隐藏邮件地址。 |
+| `inbox_config.json` | 本地文件 | 保存接收邮箱 IMAP 配置。 |
+| `hidemyemail.db` | 本地文件 | 保存地址、邮件元数据和验证码的 SQLite 数据库。 |
+
+## 本地文件
+
+以下文件只在本地使用，已加入 Git 忽略：
+
+- `cookies.txt`
+- `cookies.txt.bak`
+- `emails.txt`
+- `hidemyemail.db`
+- `hidemyemail.db-*`
+- `inbox_config.json`
+- `exports/`
+- `.cookie-browser-profile/`
+- `.venv/`
+
+## 故障排查
+
+| 现象 | 处理方式 |
+| --- | --- |
+| `Missing X-APPLE-WEBAUTH-USER cookie` | 捕获「隐藏邮件地址」应用请求，不要使用 `feedbackws/reportStats`。 |
+| `Request timed out` | 重试。命令行已经增加超时和重试，但 iCloud 偶尔仍会慢。 |
+| Cookie 对应账号不对 | 用启动器 `4 -> 1` 查看账号，再用 `4 -> 3` 重新捕获。 |
+| 自动捕获无法打开浏览器 | 安装 Microsoft Edge，然后运行 `uv sync --extra capture` 或 `uv run playwright install chromium`。 |
+| 中文在旧控制台里乱码 | 使用启动器；启动器会切换到 UTF-8。 |
+| IMAP 登录失败 | 确认邮箱已开启 IMAP，并按邮箱服务商要求使用应用专用密码。 |
+| 没有识别出验证码 | 用 `hidemyemail inbox messages` 查看标题和正文预览；有些服务商格式不标准。 |
+
+## 安全和隐私
+
+- Cookie 只保存在本地，并已被 Git 忽略。
+- IMAP 配置和本地收件数据只保存在本地，并已被 Git 忽略。
+- 自动捕获使用独立浏览器配置。
+- 项目不会主动收集、上传或分享你的 Cookie、邮件数据或验证码。
+- 不要提交 `cookies.txt`、`cookies.txt.bak`、`emails.txt`、`inbox_config.json`、`hidemyemail.db`、导出目录或浏览器配置目录。
+- 如果 token 或 Cookie 被意外公开，请到对应平台撤销或重新生成。
+
+## 频率限制
+
+Apple 可能限制「隐藏邮件地址」创建频率。经验值大约是：
+每 30 分钟可创建 `5 * iCloud 家庭人数` 个地址，观察到的总量上限约为 700 个。
+
+## 免责声明
+
+本项目是独立社区工具，不隶属于 Apple Inc.，也未获得 Apple Inc. 的认可或赞助。
+Apple、iCloud 和 Hide My Email 是 Apple Inc. 的商标。
+
+## 致谢
+
+- iCloud 中国区支持、Windows 启动器和本地收件台由 [@never-seek](https://github.com/never-seek) 贡献。
+- 同时感谢其他[社区贡献者](https://github.com/rtunazzz/hidemyemail-generator/graphs/contributors)。
+
+## 许可证
+
+MIT。见 [LICENSE](./LICENSE)。

--- a/src/hidemyemail_generator/inbox.py
+++ b/src/hidemyemail_generator/inbox.py
@@ -271,7 +271,6 @@ def extract_verification_code(subject: str, body: str) -> str:
             if re.fullmatch(r"(?:19|20)\d{2}", code):
                 continue
             score = base_score
-            score += 100
             if len(code) == 6:
                 score += 20
             if len(code) in (4, 5, 7, 8):

--- a/src/hidemyemail_generator/launcher.py
+++ b/src/hidemyemail_generator/launcher.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 
-REGION = os.environ.get("HIDEMYEMAIL_REGION", "global")
+REGION = os.environ.get("HIDEMYEMAIL_REGION", "global").lower()
 COOKIE_FILE = "cookies.txt"
 
 
@@ -26,7 +26,7 @@ def clear() -> None:
 
 
 def pause() -> None:
-    input("\n按 Enter 继续 / Press Enter to continue...")
+    input("\nPress Enter to continue / 按 Enter 继续...")
 
 
 def run_cli(*args: str) -> int:
@@ -42,11 +42,11 @@ def has_cookies() -> bool:
 def ensure_cookies() -> bool:
     if has_cookies():
         return True
-    print("[INFO] cookies.txt 不存在或为空 / cookies.txt is missing or empty.")
+    print("[INFO] cookies.txt is missing or empty / cookies.txt 不存在或为空.")
     show_cookie_help()
     if has_cookies():
         return True
-    print("[ERROR] cookies.txt 仍然为空 / cookies.txt is still empty.")
+    print("[ERROR] cookies.txt is still empty / cookies.txt 仍然为空.")
     pause()
     return False
 
@@ -69,27 +69,29 @@ def open_notepad(path: str) -> None:
 def show_cookie_help() -> None:
     origin = icloud_origin()
     print()
-    print("将打开 iCloud 页面和 cookies.txt。")
     print("This opens iCloud and cookies.txt.")
-    print("现有 cookies.txt 不会被自动清空。")
+    print("将打开 iCloud 页面和 cookies.txt。")
     print("Existing cookies.txt will not be cleared automatically.")
-    print("如需替换，请在记事本中按 Ctrl+A，粘贴新的 cURL 内容，然后保存。")
+    print("现有 cookies.txt 不会被自动清空。")
     print("To replace it, press Ctrl+A in Notepad, paste the new cURL text, then save.")
-    print("打开记事本前会备份为 cookies.txt.bak。")
+    print("如需替换，请在记事本中按 Ctrl+A，粘贴新的 cURL 内容，然后保存。")
     print("A backup will be saved as cookies.txt.bak before Notepad opens.")
+    print("打开记事本前会备份为 cookies.txt.bak。")
     print()
-    print("浏览器操作步骤 / Steps in your browser:")
-    print(f"1. 登录 {origin}/settings/")
-    print("2. 按 F12")
-    print("3. 点击 Network / 网络")
-    print("4. 刷新页面")
-    print("5. 在过滤框搜索 hme 或 maildomainws")
-    print("6. 如果看到 maildomainws 或 hme 请求，右键它")
-    print("   如果只有其他请求，选择已登录状态下的设置页请求")
-    print("   不要使用 feedbackws/reportStats，因为它通常缺少授权 Cookie")
-    print("7. 点击 Copy / 复制，然后 Copy as cURL / 复制为 cURL")
-    print("8. 将整段内容粘贴到 cookies.txt")
-    print("9. 保存并关闭记事本")
+    print("Steps in your browser / 浏览器操作步骤:")
+    print(f"1. Sign in to {origin}/settings/ / 登录")
+    print("2. Press F12 / 按 F12")
+    print("3. Open the Network tab / 点击 Network 网络")
+    print("4. Refresh the page / 刷新页面")
+    print("5. Search hme or maildomainws in the filter box / 在过滤框搜索 hme 或 maildomainws")
+    print("6. Right-click a maildomainws or hme request if one appears;")
+    print("   otherwise pick a signed-in settings request.")
+    print("   Avoid feedbackws/reportStats; it usually misses the auth cookie.")
+    print("   如果看到 maildomainws 或 hme 请求，右键它；否则选择已登录状态下的设置页请求。")
+    print("   不要使用 feedbackws/reportStats，因为它通常缺少授权 Cookie。")
+    print("7. Choose Copy, then Copy as cURL / 点击 Copy 复制，然后 Copy as cURL 复制为 cURL")
+    print("8. Paste the whole text into cookies.txt / 将整段内容粘贴到 cookies.txt")
+    print("9. Save and close Notepad / 保存并关闭记事本")
     print()
 
     cookie_path = Path(COOKIE_FILE)
@@ -105,14 +107,14 @@ def main_menu() -> None:
         clear()
         print("HideMyEmail Generator / iCloud 隐藏邮箱工具")
         print()
-        print("1. 生成隐藏邮箱 / Generate emails")
-        print("2. 查看使用中地址 / List active emails")
-        print("3. 查看已停用地址 / List inactive emails")
-        print("4. 管理 iCloud Cookie / Manage iCloud cookie")
-        print("5. 本地收件台和验证码 / Local inbox and codes")
-        print("6. 退出 / Exit")
+        print("1. Generate emails / 生成隐藏邮箱")
+        print("2. List active emails / 查看使用中地址")
+        print("3. List inactive emails / 查看已停用地址")
+        print("4. Manage iCloud cookie / 管理 iCloud Cookie")
+        print("5. Local inbox and codes / 本地收件台和验证码")
+        print("6. Exit / 退出")
         print()
-        choice = input("请选择 / Choose an option [1-6]: ").strip()
+        choice = input("Choose an option / 请选择 [1-6]: ").strip()
 
         if choice == "1":
             generate()
@@ -132,8 +134,8 @@ def generate() -> None:
     if not ensure_cookies():
         return
     print()
-    label = input("标签 / Label for generated emails: ").strip() or "generated"
-    count = input("生成数量 / How many emails to generate [1]: ").strip() or "1"
+    label = input("Label for generated emails / 标签: ").strip() or "generated"
+    count = input("How many emails to generate / 生成数量 [1]: ").strip() or "1"
     code = run_cli(
         "generate",
         "--label",
@@ -148,7 +150,7 @@ def generate() -> None:
         REGION,
     )
     if code:
-        print("[ERROR] 生成失败 / Generate command failed.")
+        print("[ERROR] Generate command failed / 生成失败.")
     pause()
 
 
@@ -157,7 +159,7 @@ def list_active() -> None:
         return
     code = run_cli("list", "--active", "--cookie-file", COOKIE_FILE, "--region", REGION)
     if code:
-        print("[ERROR] 查看使用中地址失败 / List active command failed.")
+        print("[ERROR] List active command failed / 查看使用中地址失败.")
     pause()
 
 
@@ -166,21 +168,21 @@ def list_inactive() -> None:
         return
     code = run_cli("list", "--inactive", "--cookie-file", COOKIE_FILE, "--region", REGION)
     if code:
-        print("[ERROR] 查看已停用地址失败 / List inactive command failed.")
+        print("[ERROR] List inactive command failed / 查看已停用地址失败.")
     pause()
 
 
 def cookie_menu() -> None:
     while True:
         clear()
-        print("iCloud Cookie 管理 / iCloud Cookie")
+        print("iCloud Cookie / iCloud Cookie 管理")
         print()
-        print("1. 查看当前 Cookie 账号 / Show current cookie account")
-        print("2. 手动替换 iCloud Cookie / Replace iCloud cookie")
-        print("3. 自动获取 iCloud Cookie / Auto capture iCloud cookie")
-        print("4. 返回 / Back")
+        print("1. Show current cookie account / 查看当前 Cookie 账号")
+        print("2. Replace iCloud cookie / 手动替换 iCloud Cookie")
+        print("3. Auto capture iCloud cookie / 自动获取 iCloud Cookie")
+        print("4. Back / 返回")
         print()
-        choice = input("请选择 / Choose an option [1-4]: ").strip()
+        choice = input("Choose an option / 请选择 [1-4]: ").strip()
 
         if choice == "1":
             show_cookie_account()
@@ -195,48 +197,48 @@ def cookie_menu() -> None:
 
 def show_cookie_account() -> None:
     if not has_cookies():
-        print("[INFO] cookies.txt 不存在或为空 / cookies.txt is missing or empty.")
-        print("请使用选项 2 添加 iCloud Cookie / Use option 2 to add an iCloud cookie.")
+        print("[INFO] cookies.txt is missing or empty / cookies.txt 不存在或为空.")
+        print("Use option 2 to add an iCloud cookie / 请使用选项 2 添加 iCloud Cookie.")
         pause()
         return
     code = run_cli("whoami", "--cookie-file", COOKIE_FILE, "--region", REGION)
     if code:
-        print("[ERROR] 无法识别当前 Cookie 账号 / Could not identify current cookie account.")
+        print("[ERROR] Could not identify current cookie account / 无法识别当前 Cookie 账号.")
     pause()
 
 
 def auto_capture_cookies() -> None:
     print()
-    print("将打开一个独立浏览器配置用于获取 Cookie。")
     print("This opens a separate browser profile for cookie capture.")
-    print("如需登录，请在浏览器中登录。工具会打开 iCloud+，点击隐藏邮件地址，")
-    print("捕获应用请求并保存 cookies.txt。")
+    print("将打开一个独立浏览器配置用于获取 Cookie。")
     print("Log in if needed. The tool will open iCloud Plus, click Hide My Email,")
     print("capture the Hide My Email app request, and save cookies.txt.")
+    print("如需登录请在浏览器中登录。工具会打开 iCloud+，点击隐藏邮件地址，")
+    print("捕获应用请求并保存 cookies.txt。")
     print()
     code = run_cli("capture-cookie", "--cookie-file", COOKIE_FILE, "--region", REGION)
     if code:
-        print("[ERROR] 自动获取 Cookie 失败 / Auto cookie capture failed.")
+        print("[ERROR] Auto cookie capture failed / 自动获取 Cookie 失败.")
     pause()
 
 
 def inbox_menu() -> None:
     while True:
         clear()
-        print("本地收件台和验证码 / Local Inbox and Codes")
+        print("Local Inbox and Codes / 本地收件台和验证码")
         print()
-        print("1. 配置收件邮箱 IMAP / Configure inbox IMAP account")
-        print("2. 同步收件箱并显示验证码 / Sync inbox and show verification codes")
-        print("3. 查看最近验证码 / Show recent verification codes")
-        print("4. 查看最近邮件 / Show recent inbox messages")
-        print("5. 查看未使用本地邮箱 / List unused local emails")
-        print("6. 标记邮箱为已使用 / Mark email as used")
-        print("7. 移入垃圾箱 / Move email to trash")
-        print("8. 同步 iCloud 隐藏邮箱到本地库 / Sync iCloud HME addresses to local DB")
-        print("9. 导出 CSV 表格 / Export CSV files")
-        print("10. 返回 / Back")
+        print("1. Configure inbox IMAP account / 配置收件邮箱 IMAP")
+        print("2. Sync inbox and show verification codes / 同步收件箱并显示验证码")
+        print("3. Show recent verification codes / 查看最近验证码")
+        print("4. Show recent inbox messages / 查看最近邮件")
+        print("5. List unused local emails / 查看未使用本地邮箱")
+        print("6. Mark email as used / 标记邮箱为已使用")
+        print("7. Move email to trash / 移入垃圾箱")
+        print("8. Sync iCloud HME addresses to local DB / 同步 iCloud 隐藏邮箱到本地库")
+        print("9. Export CSV files / 导出 CSV 表格")
+        print("10. Back / 返回")
         print()
-        choice = input("请选择 / Choose an option [1-10]: ").strip()
+        choice = input("Choose an option / 请选择 [1-10]: ").strip()
 
         if choice == "1":
             inbox_setup()
@@ -262,59 +264,59 @@ def inbox_menu() -> None:
 
 def inbox_setup() -> None:
     print()
-    print("配置用于接收转发邮件的邮箱 IMAP 账号。")
     print("Configure your receiving mailbox IMAP account.")
-    print("很多邮箱需要使用“应用专用密码”，不要用网页登录密码。")
-    print("For many providers, use an app password instead of the normal login password.")
-    print("配置会保存在本地 inbox_config.json。")
+    print("配置用于接收转发邮件的邮箱 IMAP 账号。")
+    print("For many providers, use an app password instead of the login password.")
+    print("很多邮箱需要使用应用专用密码，不要用网页登录密码。")
     print("The config is saved locally in inbox_config.json.")
+    print("配置会保存在本地 inbox_config.json。")
     print()
     code = run_cli("inbox", "setup")
     if code:
-        print("[ERROR] 收件台配置失败 / Inbox setup failed.")
+        print("[ERROR] Inbox setup failed / 收件台配置失败.")
     pause()
 
 
 def inbox_sync() -> None:
     code = run_cli("inbox", "sync", "--limit", "100", "--show-codes")
     if code:
-        print("[ERROR] 收件箱同步失败 / Inbox sync failed.")
+        print("[ERROR] Inbox sync failed / 收件箱同步失败.")
     pause()
 
 
 def inbox_codes() -> None:
     code = run_cli("inbox", "codes", "--limit", "30")
     if code:
-        print("[ERROR] 无法显示验证码 / Could not show codes.")
+        print("[ERROR] Could not show codes / 无法显示验证码.")
     pause()
 
 
 def inbox_messages() -> None:
     code = run_cli("inbox", "messages", "--limit", "30")
     if code:
-        print("[ERROR] 无法显示邮件 / Could not show messages.")
+        print("[ERROR] Could not show messages / 无法显示邮件.")
     pause()
 
 
 def inbox_unused() -> None:
     code = run_cli("inbox", "addresses", "--state", "unused", "--limit", "100")
     if code:
-        print("[ERROR] 无法显示本地邮箱 / Could not show local emails.")
+        print("[ERROR] Could not show local emails / 无法显示本地邮箱.")
     pause()
 
 
 def inbox_mark(state: str) -> None:
     prompt = (
-        "要标记为已使用的邮箱 / Email to mark as used: "
+        "Email to mark as used / 要标记为已使用的邮箱: "
         if state == "used"
-        else "要移入垃圾箱的邮箱 / Email to move to trash: "
+        else "Email to move to trash / 要移入垃圾箱的邮箱: "
     )
     email = input(prompt).strip()
     if not email:
         return
     code = run_cli("inbox", "mark", email, state)
     if code:
-        print("[ERROR] 无法标记邮箱 / Could not mark email.")
+        print("[ERROR] Could not mark email / 无法标记邮箱.")
     pause()
 
 
@@ -323,14 +325,14 @@ def inbox_sync_hme() -> None:
         return
     code = run_cli("inbox", "sync-hme", "--cookie-file", COOKIE_FILE, "--region", REGION)
     if code:
-        print("[ERROR] 无法同步 iCloud 隐藏邮箱 / Could not sync iCloud HME addresses.")
+        print("[ERROR] Could not sync iCloud HME addresses / 无法同步 iCloud 隐藏邮箱.")
     pause()
 
 
 def inbox_export() -> None:
     code = run_cli("inbox", "export")
     if code:
-        print("[ERROR] 导出失败 / Export failed.")
+        print("[ERROR] Export failed / 导出失败.")
     pause()
 
 

--- a/src/hidemyemail_generator/main.py
+++ b/src/hidemyemail_generator/main.py
@@ -51,6 +51,10 @@ COOKIE_CAPTURE_URLS = {
 HIDEMYEMAIL_APP_PATH = "/applications/hidemyemail/current/"
 
 
+def maildomain_suffix(region: str) -> str:
+    return "com.cn" if region == "china" else "com"
+
+
 def load_cookie_context(cookie_file: str, region: str) -> tuple[str, str]:
     with open(cookie_file, "r") as f:
         content = "\n".join(
@@ -83,8 +87,9 @@ def load_cookie_context(cookie_file: str, region: str) -> tuple[str, str]:
         r"https://(p\d+)-[^/\s'\"]+\.icloud\.com(?:\.cn)?", normalized_content
     )
     if shard:
-        suffix = "com.cn" if region == "china" else "com"
-        maildomain_host = f"{shard.group(1)}-maildomainws.icloud.{suffix}"
+        maildomain_host = (
+            f"{shard.group(1)}-maildomainws.icloud.{maildomain_suffix(region)}"
+        )
 
     cmd_cookie_arg = re.search(
         r"(?:^|\s)(?:-b|--cookie)\s+\^\"(.+?)\^\"\s+\^?\s*-[A-Za-z]",
@@ -118,10 +123,6 @@ def load_cookie_context(cookie_file: str, region: str) -> tuple[str, str]:
 
     lines = normalized_content.splitlines()
     return (lines[0].strip() if lines else ""), maildomain_host
-
-
-def load_cookie_string(cookie_file: str) -> str:
-    return load_cookie_context(cookie_file, DEFAULT_REGION)[0]
 
 
 async def fetch_account_info(cookie_file: str, region: str) -> dict:
@@ -163,8 +164,9 @@ async def fetch_account_info_from_cookie(
 
     user_partition = data.get("userPartition")
     if not maildomain_host and user_partition:
-        suffix = "com.cn" if region == "china" else "com"
-        maildomain_host = f"p{user_partition}-maildomainws.icloud.{suffix}"
+        maildomain_host = (
+            f"p{user_partition}-maildomainws.icloud.{maildomain_suffix(region)}"
+        )
 
     data["detectedMaildomainHost"] = maildomain_host
     return data


### PR DESCRIPTION
Post-merge cleanup of the iCloud China / Windows work (#45), plus a docs pass.

## Code
- Make `global` the effective default region, and normalize the launcher's
  `HIDEMYEMAIL_REGION` casing (`.lower()`) so mixed-case values (e.g. `China`)
  resolve to the correct origin instead of silently falling back to global.
- Launcher output is English-first with complete bilingual coverage (some
  steps were previously Chinese-only).
- Remove dead code (`load_cookie_string`), dedup the region maildomain suffix
  into one helper, and drop a no-op constant in verification-code scoring.

## Docs
- README: trimmed the badge row to a professional set (license, Python,
  latest release, downloads), removed the self-referential **Upstream** link,
  switched examples to `global` defaults, and credited contributors.
- Split the Simplified Chinese section into `README.zh-CN.md` with a language
  switcher (kept the China example in the Chinese README).
- Generalized `COOKIE_HELP.md` from China-only to global-default.

No dependency or behavior changes for existing default (`global`) users.
`ruff` clean, tests pass.