### PR TITLE
Release workflow: standalone Windows + macOS binaries (v2.0.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: windows
+            binary: dist/hidemyemail-windows.exe
+          - os: macos-latest
+            name: macos
+            binary: dist/hidemyemail-macos
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Build binary
+        shell: bash
+        run: |
+          if [ "${{ matrix.name }}" = "windows" ]; then
+            uv run --with pyinstaller pyinstaller --onefile \
+              --name hidemyemail-windows \
+              --collect-data certifi \
+              --icon docs/icon.ico \
+              src/hidemyemail_generator/__main__.py
+          else
+            uv run --with pyinstaller pyinstaller --onefile \
+              --name hidemyemail-macos \
+              --collect-data certifi \
+              src/hidemyemail_generator/__main__.py
+          fi
+
+      - name: Attach binary to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.binary }}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ Alongside the basics it provides:
 
 ## Quick Start
 
+### Download a prebuilt binary
+
+Grab a standalone binary from the [latest release](https://github.com/rtunazzz/hidemyemail-generator/releases/latest) — no Python or `uv` required.
+
+- **Windows:** download `hidemyemail-windows.exe`. Double-click it to open the interactive menu, or run it from a terminal with arguments for CLI usage (`hidemyemail-windows.exe --help`).
+- **macOS:** download `hidemyemail-macos`, then `chmod +x hidemyemail-macos`. Run with no arguments to open the menu, or pass arguments for the CLI. The binary is unsigned, so the first launch is blocked by Gatekeeper — right-click it in Finder and choose **Open** to allow it.
+
+The prebuilt binaries use manual cookie capture; automatic capture (Playwright) is only available when running from source.
+
+### Run from source
+
 ```bash
 git clone https://github.com/rtunazzz/hidemyemail-generator.git
 cd hidemyemail-generator

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,6 +56,17 @@
 
 ## 快速开始
 
+### 下载预构建二进制
+
+从[最新发行版](https://github.com/rtunazzz/hidemyemail-generator/releases/latest)下载独立二进制文件，无需安装 Python 或 `uv`。
+
+- **Windows：** 下载 `hidemyemail-windows.exe`。双击打开交互式菜单，或在终端中带参数运行以使用命令行（`hidemyemail-windows.exe --help`）。
+- **macOS：** 下载 `hidemyemail-macos`，然后执行 `chmod +x hidemyemail-macos`。不带参数运行会打开菜单，带参数则进入命令行。该二进制未签名，首次启动会被 Gatekeeper 拦截——在访达中右键点击并选择**打开**即可放行。
+
+预构建二进制使用手动获取 Cookie；自动获取（Playwright）仅在源码运行时可用。
+
+### 源码运行
+
 ```bash
 git clone https://github.com/rtunazzz/hidemyemail-generator.git
 cd hidemyemail-generator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hidemyemail_generator"
-version = "1.0.0"
+version = "2.0.0"
 description = "Generate and manage iCloud Hide My Email addresses"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hidemyemail_generator/__main__.py
+++ b/src/hidemyemail_generator/__main__.py
@@ -1,0 +1,16 @@
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) > 1:
+        from hidemyemail_generator.main import cli
+
+        cli()
+    else:
+        from hidemyemail_generator.launcher import main as launcher_main
+
+        launcher_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hidemyemail_generator/launcher.py
+++ b/src/hidemyemail_generator/launcher.py
@@ -30,7 +30,10 @@ def pause() -> None:
 
 
 def run_cli(*args: str) -> int:
-    command = [sys.executable, "-m", "hidemyemail_generator.main", *args]
+    if getattr(sys, "frozen", False):
+        command = [sys.executable, *args]
+    else:
+        command = [sys.executable, "-m", "hidemyemail_generator.main", *args]
     return subprocess.run(command).returncode
 
 
@@ -179,7 +182,10 @@ def cookie_menu() -> None:
         print()
         print("1. Show current cookie account / 查看当前 Cookie 账号")
         print("2. Replace iCloud cookie / 手动替换 iCloud Cookie")
-        print("3. Auto capture iCloud cookie / 自动获取 iCloud Cookie")
+        auto_capture_label = "3. Auto capture iCloud cookie / 自动获取 iCloud Cookie"
+        if getattr(sys, "frozen", False):
+            auto_capture_label += " (source only / 仅源码可用)"
+        print(auto_capture_label)
         print("4. Back / 返回")
         print()
         choice = input("Choose an option / 请选择 [1-4]: ").strip()

--- a/src/hidemyemail_generator/main.py
+++ b/src/hidemyemail_generator/main.py
@@ -3,6 +3,7 @@ import base64
 import datetime
 import os
 import shutil
+import sys
 from typing import Union, List, Optional
 import re
 import ssl
@@ -908,9 +909,16 @@ async def _capture_cookie(cookie_file: str, region: str = DEFAULT_REGION) -> boo
     try:
         from playwright.async_api import async_playwright
     except ImportError:
-        console.log(
-            "[bold red][ERR][/] Playwright is not installed. Run: uv sync --extra capture"
-        )
+        if getattr(sys, "frozen", False):
+            console.log(
+                "[bold red][ERR][/] Auto capture is not available in the prebuilt binary. "
+                "Run from source (uv sync --extra capture) or use manual cookie capture. / "
+                "预构建二进制不支持自动获取，请使用源码运行或手动获取 Cookie。"
+            )
+        else:
+            console.log(
+                "[bold red][ERR][/] Playwright is not installed. Run: uv sync --extra capture"
+            )
         return False
 
     profile_dir = Path(".cookie-browser-profile").resolve()


### PR DESCRIPTION
## Summary
Automates the previously hand-built PyInstaller releases: every `v*` tag now builds and attaches standalone Windows + macOS binaries to the GitHub release.

- **`__main__.py`** dispatches: no args → launcher menu, any args → Click CLI, so one frozen binary is both the double-click menu and the CLI. Also makes `python -m hidemyemail_generator` work.
- **`launcher.run_cli`** re-invokes the exe itself (`[sys.executable, *args]`) when `sys.frozen`, since `python -m ...` doesn't exist in a frozen binary. Auto-capture is flagged `(source only)` in the frozen menu.
- **`main._capture_cookie`** shows a build-appropriate message when Playwright is missing (frozen users can't `uv sync`).
- **`.github/workflows/release.yml`** — matrix over `windows-latest` + `macos-latest` (`fail-fast: false`), `astral-sh/setup-uv@v5` on Python 3.12, `uv run --with pyinstaller pyinstaller --onefile --collect-data certifi` (`--icon docs/icon.ico` on Windows), then `softprops/action-gh-release@v2`.
- **Docs** — "Download a prebuilt binary" Quick Start section in `README.md` and `README.zh-CN.md`.
- Version bumped to **2.0.0**.

## Notes
- Playwright is intentionally **not** bundled (optional extra); the lean binary uses manual cookie capture.
- `--collect-data certifi` is required for TLS in the frozen binary. Python pinned to 3.12 to match `requires-python`.

## Testing
Pushed a throwaway `v0.0.0-rc.test` tag — both jobs passed and attached `hidemyemail-macos` (~14MB) and `hidemyemail-windows.exe` (~15.5MB) to the release. Test tag/release deleted afterward. Also verified locally: both dispatch paths and a frozen `--onefile` macOS build (menu, CLI, and the `(source only)` note).