### PR TITLE
feat(macos): add Sparkle EdDSA public key

### DIFF
--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -30,5 +30,7 @@
 	<true/>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>SUPublicEDKey</key>
+	<string>CTtQVjKq6ytg65Ntiv3WLuwMljBcPqW0YB1ep0VLkJw=</string>
 </dict>
 </plist>


### PR DESCRIPTION
Adds `SUPublicEDKey` to `macos/Info.plist` ahead of the Sparkle auto-update work.

This value is the trust anchor Sparkle uses to verify update payloads before installing them. Since the distributable ZIP/DMG are deliberately identity-free (no Apple team signature), the EdDSA signature is the *only* integrity check on an update — so this key is landing in its own commit rather than arriving alongside the updater implementation.

**Public key:** `CTtQVjKq6ytg65Ntiv3WLuwMljBcPqW0YB1ep0VLkJw=`

The matching private key is stored as the `SPARKLE_PRIVATE_KEY` secret in the `release` environment, which is restricted to `v*` tags.

### Not included here

- `SUFeedURL` — depends on where the appcast gets hosted
- the signing job itself — belongs with the updater implementation

### Notes for the signing job

- It must declare `environment: release`, or the secret resolves empty *and* no approval gate fires.
- It needs to be a **separate job** from the existing `macos` build job. Putting `environment: release` on that job would gate every build behind manual approval and put the key in scope for `scripts/build-macos-app.sh`.
- Sign via stdin: `echo "$SPARKLE_PRIVATE_KEY" | sign_update --ed-key-file - -p <file>`. The `-s <key>` flag is deprecated and **hard-fails** on modern keys (`sign_update/main.swift` passes `allowNewFormat: false` for that path). It also exposes the key in argv.
- Keep the secret in the signing *step*'s `env:`, not the job's.

`sign_update` ships in `Sparkle-2.9.4.tar.xz` under `bin/`.