### PR TITLE
feat(macos): add secure in-app updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,34 @@ permissions:
   contents: write
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Validate version and signing key
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml | head -1)"
+          test "${GITHUB_REF_NAME}" = "v${version}"
+          test -n "${SPARKLE_PRIVATE_KEY}"
+
+      - name: Test CLI
+        env:
+          PYTHONPATH: src
+        run: |
+          uv run --frozen pytest -q
+          uv run --frozen ruff check
+
   windows:
+    needs: validate
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,12 +55,14 @@ jobs:
           --icon docs/icon.ico
           src/hidemyemail_generator/__main__.py
 
-      - name: Attach binary to release
-        uses: softprops/action-gh-release@v2
+      - uses: actions/upload-artifact@v4
         with:
-          files: dist/hidemyemail-windows.exe
+          name: release-windows
+          path: dist/hidemyemail-windows.exe
+          if-no-files-found: error
 
   macos:
+    needs: validate
     strategy:
       fail-fast: false
       matrix:
@@ -56,16 +85,107 @@ jobs:
           enable-cache: true
 
       - name: Build CLI and app
-        shell: bash
         run: |
           scripts/build-macos-app.sh "${{ matrix.arch }}"
           cp "build/macos-app-${{ matrix.arch }}/helper/hidemyemail" \
             "dist/${{ matrix.cli_asset }}"
 
-      - name: Attach macOS assets to release
-        uses: softprops/action-gh-release@v2
+      - name: Test app
+        run: |
+          cd macos
+          xcodebuild test \
+            -scheme HideMyEmailGenerator \
+            -destination "platform=macOS,arch=${{ matrix.arch }}" \
+            -derivedDataPath "$PWD/../build/macos-app-${{ matrix.arch }}/xcode" \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Validate app bundle
+        shell: bash
+        run: |
+          app="build/macos-app-${{ matrix.arch }}/HideMyEmail Generator.app"
+          plist="$app/Contents/Info.plist"
+          version="${GITHUB_REF_NAME#v}"
+
+          test -x "$app/Contents/Resources/hidemyemail"
+          test -x "$app/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$plist")" = "$version"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' "$plist")" \
+            = "KjzTPT1ZjrInPL792a1lm9r5e/n0fyaQgsnOvkLMLCM="
+          /usr/libexec/PlistBuddy -c 'Print :SUFeedURL' "$plist" \
+            | grep -Fq "appcast-${{ matrix.arch }}.xml"
+          test "$(lipo -archs "$app/Contents/MacOS/HideMyEmailGenerator")" \
+            = "${{ matrix.arch }}"
+          test "$(lipo -archs "$app/Contents/Resources/hidemyemail")" \
+            = "${{ matrix.arch }}"
+          lipo -archs "$app/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle" \
+            | grep -Fqw "${{ matrix.arch }}"
+
+      - name: Generate signed appcast
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          updates="build/appcast-${{ matrix.arch }}"
+          archive="HideMyEmail-Generator-macOS-${{ matrix.app_label }}.zip"
+          tools="build/macos-app-${{ matrix.arch }}/xcode/SourcePackages/artifacts/sparkle/Sparkle/bin"
+          mkdir -p "$updates"
+          cp "dist/$archive" "$updates/$archive"
+
+          printf '%s' "$SPARKLE_PRIVATE_KEY" \
+            | "$tools/generate_appcast" \
+                --ed-key-file - \
+                --download-url-prefix \
+                  "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/" \
+                --link "https://github.com/${GITHUB_REPOSITORY}" \
+                --maximum-deltas 0 \
+                -o "$updates/appcast-${{ matrix.arch }}.xml" \
+                "$updates"
+
+          cp "$updates/appcast-${{ matrix.arch }}.xml" dist/
+          appcast="dist/appcast-${{ matrix.arch }}.xml"
+          signature="$(sed -n 's/.*sparkle:edSignature=\"\\([^\"]*\\)\".*/\\1/p' "$appcast")"
+          test -n "$signature"
+          grep -Fq "/releases/download/${GITHUB_REF_NAME}/$archive" \
+            "$appcast"
+          printf '%s' "$SPARKLE_PRIVATE_KEY" \
+            | "$tools/sign_update" --verify --ed-key-file - \
+                "$updates/$archive" "$signature"
+
+          invalid_signature="${signature%?}A"
+          if printf '%s' "$SPARKLE_PRIVATE_KEY" \
+            | "$tools/sign_update" --verify --ed-key-file - \
+                "$updates/$archive" "$invalid_signature" >/dev/null 2>&1; then
+            echo "Sparkle accepted an invalid update signature." >&2
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
         with:
-          files: |
+          name: release-macos-${{ matrix.arch }}
+          path: |
             dist/${{ matrix.cli_asset }}
             dist/HideMyEmail-Generator-macOS-${{ matrix.app_label }}.zip
             dist/HideMyEmail-Generator-macOS-${{ matrix.app_label }}.dmg
+            dist/appcast-${{ matrix.arch }}.xml
+          if-no-files-found: error
+
+  release:
+    needs: [windows, macos]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Validate release assets
+        run: |
+          test "$(find release-assets -maxdepth 1 -type f | wc -l)" -eq 9
+          test -f release-assets/appcast-arm64.xml
+          test -f release-assets/appcast-x86_64.xml
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: release-assets/*
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   validate:
@@ -60,7 +60,6 @@ jobs:
 
   macos:
     needs: validate
-    environment: release
     strategy:
       fail-fast: false
       matrix:
@@ -118,6 +117,47 @@ jobs:
           lipo -archs "$app/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle" \
             | grep -Fqw "${{ matrix.arch }}"
 
+      - name: Stage unsigned release
+        shell: bash
+        run: |
+          stage="build/unsigned-${{ matrix.arch }}"
+          tools="build/macos-app-${{ matrix.arch }}/xcode/SourcePackages/artifacts/sparkle/Sparkle/bin"
+          mkdir -p "$stage"
+          cp \
+            "dist/${{ matrix.cli_asset }}" \
+            "dist/HideMyEmail-Generator-macOS-${{ matrix.app_label }}.zip" \
+            "dist/HideMyEmail-Generator-macOS-${{ matrix.app_label }}.dmg" \
+            "$stage/"
+          cp -R "$tools" "$stage/tools"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-macos-${{ matrix.arch }}
+          path: build/unsigned-${{ matrix.arch }}/
+          if-no-files-found: error
+
+  sign:
+    needs: macos
+    environment: release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            arch: arm64
+            cli_asset: hidemyemail-macos
+            app_label: Apple-Silicon
+          - runner: macos-15-intel
+            arch: x86_64
+            cli_asset: hidemyemail-macos-x86_64
+            app_label: Intel
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: unsigned-macos-${{ matrix.arch }}
+          path: unsigned
+
       - name: Generate signed appcast
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
@@ -125,9 +165,13 @@ jobs:
         run: |
           updates="build/appcast-${{ matrix.arch }}"
           archive="HideMyEmail-Generator-macOS-${{ matrix.app_label }}.zip"
-          tools="build/macos-app-${{ matrix.arch }}/xcode/SourcePackages/artifacts/sparkle/Sparkle/bin"
-          mkdir -p "$updates"
-          cp "dist/$archive" "$updates/$archive"
+          tools="unsigned/tools"
+          chmod +x \
+            "$tools/BinaryDelta" \
+            "$tools/generate_appcast" \
+            "$tools/sign_update"
+          mkdir -p "$updates" dist
+          cp "unsigned/$archive" "$updates/$archive"
 
           printf '%s' "$SPARKLE_PRIVATE_KEY" \
             | "$tools/generate_appcast" \
@@ -141,7 +185,7 @@ jobs:
 
           cp "$updates/appcast-${{ matrix.arch }}.xml" dist/
           appcast="dist/appcast-${{ matrix.arch }}.xml"
-          signature="$(sed -n 's/.*sparkle:edSignature=\"\\([^\"]*\\)\".*/\\1/p' "$appcast")"
+          signature="$(sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p' "$appcast")"
           test -n "$signature"
           grep -Fq "/releases/download/${GITHUB_REF_NAME}/$archive" \
             "$appcast"
@@ -157,6 +201,12 @@ jobs:
             exit 1
           fi
 
+          cp \
+            "unsigned/${{ matrix.cli_asset }}" \
+            "unsigned/HideMyEmail-Generator-macOS-${{ matrix.app_label }}.zip" \
+            "unsigned/HideMyEmail-Generator-macOS-${{ matrix.app_label }}.dmg" \
+            dist/
+
       - uses: actions/upload-artifact@v4
         with:
           name: release-macos-${{ matrix.arch }}
@@ -168,11 +218,14 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: [windows, macos]
+    needs: [windows, sign]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:
+          pattern: release-*
           path: release-assets
           merge-multiple: true
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ The script builds one exact architecture and refuses cross-architecture
 packaging. Run it on Apple Silicon for the Apple Silicon app and on an Intel
 Mac (or the matching GitHub runner) for the Intel app.
 
+### Releasing
+
+macOS updates use Sparkle and are published only from version tags. Before the
+first updater release, an upstream maintainer must add the exported EdDSA
+private key as the `SPARKLE_PRIVATE_KEY` GitHub Actions secret. The matching
+public key is embedded in `macos/Info.plist`.
+
+1. Bump the version in `pyproject.toml`, `uv.lock`, and `macos/Info.plist`.
+2. Merge the tested change to `main`.
+3. Tag that commit with the matching `v`-prefixed version, such as `v2.1.0`.
+
+The release workflow rejects mismatched tags or a missing signing key, builds
+both Mac architectures, signs their appcasts, and publishes only after every
+artifact passes.
+
 ## Windows Launcher
 
 The Windows launcher is the recommended entry point for Windows users.

--- a/README.md
+++ b/README.md
@@ -179,10 +179,8 @@ Mac (or the matching GitHub runner) for the Intel app.
 
 ### Releasing
 
-macOS updates use Sparkle and are published only from version tags. Before the
-first updater release, an upstream maintainer must add the exported EdDSA
-private key as the `SPARKLE_PRIVATE_KEY` GitHub Actions secret. The matching
-public key is embedded in `macos/Info.plist`.
+macOS updates use Sparkle and are published only from version tags. The
+verification public key is embedded in `macos/Info.plist`.
 
 1. Bump the version in `pyproject.toml`, `uv.lock`, and `macos/Info.plist`.
 2. Merge the tested change to `main`.

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.0</string>
+	<string>2.1.0</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
@@ -30,5 +30,15 @@
 	<true/>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>SUAllowsAutomaticUpdates</key>
+	<false/>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>https://github.com/rtunazzz/hidemyemail-generator/releases/latest/download/appcast-arm64.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>KjzTPT1ZjrInPL792a1lm9r5e/n0fyaQgsnOvkLMLCM=</string>
+	<key>SUSendProfileInfo</key>
+	<false/>
 </dict>
 </plist>

--- a/macos/Package.resolved
+++ b/macos/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "92a17ee68c567d337068144e6eeb17385032ce397f367afe55c015900cc4407b",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -8,8 +8,25 @@ let package = Package(
     products: [
         .executable(name: "HideMyEmailGenerator", targets: ["HideMyEmailGenerator"])
     ],
+    dependencies: [
+        .package(
+            url: "https://github.com/sparkle-project/Sparkle",
+            exact: "2.9.4"
+        )
+    ],
     targets: [
-        .executableTarget(name: "HideMyEmailGenerator"),
+        .executableTarget(
+            name: "HideMyEmailGenerator",
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle")
+            ],
+            linkerSettings: [
+                .unsafeFlags([
+                    "-Xlinker", "-rpath",
+                    "-Xlinker", "@executable_path/../Frameworks",
+                ])
+            ]
+        ),
         .testTarget(
             name: "HideMyEmailGeneratorTests",
             dependencies: ["HideMyEmailGenerator"]

--- a/macos/Sources/HideMyEmailGenerator/HideMyEmailGeneratorApp.swift
+++ b/macos/Sources/HideMyEmailGenerator/HideMyEmailGeneratorApp.swift
@@ -1,14 +1,97 @@
 import AppKit
+@preconcurrency import Sparkle
 import SwiftUI
+
+enum UpdateStatus {
+  case checking
+  case current
+  case available
+  case unavailable
+
+  var systemImage: String {
+    self == .available ? "arrow.down.circle.fill" : "arrow.down.circle"
+  }
+
+  var help: String {
+    switch self {
+    case .checking:
+      "Checking for updates…"
+    case .current:
+      "Check for Updates…"
+    case .available:
+      "An update is available. Click to review it."
+    case .unavailable:
+      "Unable to check for updates. Click to try again."
+    }
+  }
+}
+
+@MainActor
+final class UpdateController: NSObject, ObservableObject, SPUUpdaterDelegate,
+  SPUStandardUserDriverDelegate
+{
+  @Published private(set) var status = UpdateStatus.checking
+
+  private lazy var controller = SPUStandardUpdaterController(
+    startingUpdater: true,
+    updaterDelegate: self,
+    userDriverDelegate: self
+  )
+
+  override init() {
+    super.init()
+    controller.updater.checkForUpdatesInBackground()
+  }
+
+  func checkForUpdates() {
+    status = .checking
+    controller.checkForUpdates(nil)
+  }
+
+  func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+    status = .available
+  }
+
+  func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+    status = .current
+  }
+
+  func updater(_ updater: SPUUpdater, didAbortWithError error: any Error) {
+    status = .unavailable
+  }
+
+  nonisolated var supportsGentleScheduledUpdateReminders: Bool { true }
+
+  nonisolated func standardUserDriverShouldHandleShowingScheduledUpdate(
+    _ update: SUAppcastItem,
+    andInImmediateFocus immediateFocus: Bool
+  ) -> Bool {
+    false
+  }
+
+  nonisolated func standardUserDriverWillHandleShowingUpdate(
+    _ handleShowingUpdate: Bool,
+    forUpdate update: SUAppcastItem,
+    state: SPUUserUpdateState
+  ) {
+    if !handleShowingUpdate {
+      Task { @MainActor [weak self] in
+        self?.status = .available
+      }
+    }
+  }
+}
 
 @main
 struct HideMyEmailGeneratorApp: App {
   @StateObject private var model = AppModel()
+  @StateObject private var updater = UpdateController()
 
   var body: some Scene {
     WindowGroup {
       ContentView()
         .environmentObject(model)
+        .environmentObject(updater)
         .frame(minWidth: 640, minHeight: 420)
     }
     .defaultSize(width: 850, height: 540)
@@ -40,6 +123,7 @@ enum AppSection: String, CaseIterable, Identifiable {
 
 struct ContentView: View {
   @EnvironmentObject private var model: AppModel
+  @EnvironmentObject private var updater: UpdateController
   @State private var selection = AppSection.generate
   @State private var isConfirmingSignOut = false
 
@@ -53,15 +137,22 @@ struct ContentView: View {
         .listStyle(.sidebar)
 
         Divider()
-        Label {
+        HStack(spacing: 8) {
           Text("No telemetry collected")
             .foregroundStyle(.secondary)
-        } icon: {
-          Image(systemName: "lock.shield.fill")
-            .foregroundStyle(.blue)
+
+          Spacer(minLength: 4)
+
+          Button { updater.checkForUpdates() } label: {
+            Image(systemName: updater.status.systemImage)
+              .foregroundStyle(updater.status == .available ? .green : .secondary)
+          }
+          .buttonStyle(.plain)
+          .help(updater.status.help)
+          .accessibilityLabel(updater.status.help)
         }
-          .font(.caption)
-          .padding(12)
+        .font(.caption)
+        .padding(12)
       }
       .navigationSplitViewColumnWidth(min: 160, ideal: 180, max: 220)
     } detail: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hidemyemail_generator"
-version = "2.0.0"
+version = "2.1.0"
 description = "Generate and manage iCloud Hide My Email addresses"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -4,8 +4,14 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ARCH="${1:-$(uname -m)}"
 case "$ARCH" in
-  arm64) ARCH_LABEL="Apple-Silicon" ;;
-  x86_64) ARCH_LABEL="Intel" ;;
+  arm64)
+    ARCH_LABEL="Apple-Silicon"
+    DEFAULT_FEED_URL="https://github.com/rtunazzz/hidemyemail-generator/releases/latest/download/appcast-arm64.xml"
+    ;;
+  x86_64)
+    ARCH_LABEL="Intel"
+    DEFAULT_FEED_URL="https://github.com/rtunazzz/hidemyemail-generator/releases/latest/download/appcast-x86_64.xml"
+    ;;
   *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
 esac
 if [[ "$(uname -m)" != "$ARCH" ]]; then
@@ -21,6 +27,7 @@ if [[ -z "${DEVELOPER_DIR:-}" ]]; then
   fi
 fi
 VERSION="${VERSION:-$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$ROOT/pyproject.toml" | head -1)}"
+SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-$DEFAULT_FEED_URL}"
 BUILD_ROOT="$ROOT/build/macos-app-$ARCH"
 APP="$BUILD_ROOT/HideMyEmail Generator.app"
 ASSET_BASE="$ROOT/dist/HideMyEmail-Generator-macOS-$ARCH_LABEL"
@@ -54,10 +61,14 @@ DEVELOPER_DIR="$DEVELOPER_DIR" xcodebuild \
   CODE_SIGNING_ALLOWED=NO \
   build
 
-mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+SPARKLE_FRAMEWORK="$BUILD_ROOT/xcode/Build/Products/Release/Sparkle.framework"
+test -d "$SPARKLE_FRAMEWORK"
+
+mkdir -p "$APP/Contents/Frameworks" "$APP/Contents/MacOS" "$APP/Contents/Resources"
 cp "$BUILD_ROOT/xcode/Build/Products/Release/HideMyEmailGenerator" \
   "$APP/Contents/MacOS/HideMyEmailGenerator"
 cp "$BUILD_ROOT/helper/hidemyemail" "$APP/Contents/Resources/hidemyemail"
+ditto "$SPARKLE_FRAMEWORK" "$APP/Contents/Frameworks/Sparkle.framework"
 cp "$ROOT/macos/Info.plist" "$APP/Contents/Info.plist"
 DEVELOPER_DIR="$DEVELOPER_DIR" xcrun actool \
   --compile "$APP/Contents/Resources" \
@@ -77,6 +88,7 @@ chmod 755 "$APP/Contents/MacOS/HideMyEmailGenerator" "$APP/Contents/Resources/hi
 
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" "$APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :SUFeedURL $SPARKLE_FEED_URL" "$APP/Contents/Info.plist"
 
 for binary in \
   "$APP/Contents/MacOS/HideMyEmailGenerator" \
@@ -86,6 +98,19 @@ for binary in \
     exit 1
   fi
 done
+
+test -x "$APP/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate"
+if ! otool -l "$APP/Contents/MacOS/HideMyEmailGenerator" \
+  | grep -A2 LC_RPATH \
+  | grep -Fq '@executable_path/../Frameworks'; then
+  echo "The app executable cannot load its bundled Sparkle framework." >&2
+  exit 1
+fi
+
+# Sparkle requires a structurally valid bundle signature. This identity-free
+# signature carries no Apple team and leaves release trust to the EdDSA key.
+codesign --force --sign - "$APP"
+codesign --verify --deep --strict "$APP"
 
 for artifact in \
   "$APP" \

--- a/uv.lock
+++ b/uv.lock
@@ -306,7 +306,7 @@ wheels = [
 
 [[package]]
 name = "hidemyemail-generator"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- add Sparkle 2.9.4 for EdDSA-verified macOS app and bundled CLI updates
- add a quiet launch check and sidebar update indicator with Sparkle standard manual update flow
- package Sparkle correctly for Apple Silicon and Intel builds
- publish architecture-specific signed appcasts from an atomic, tag-only release workflow
- set the updater-enabled baseline version to 2.1.0

## Release configuration

- uses the public key already merged into main
- reads SPARKLE_PRIVATE_KEY from the reviewer-gated release environment
- requires the pushed version tag to exactly match pyproject.toml
- publishes only after Windows and both macOS architectures pass

## Validation

- 9 Python tests
- 12 Swift tests
- Ruff
- complete arm64 ZIP and DMG packaging
- helper, framework symlink, rpath, architecture, version, feed, and public-key checks
- valid EdDSA signature accepted and a deliberately invalid signature rejected

After merging, push v2.1.0 to publish the updater-enabled baseline. A subsequent v2.1.1 release can exercise the first production self-update.