### PR TITLE
fix(release): prepare v2.1.1 macOS downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ verification public key is embedded in `macos/Info.plist`.
 
 1. Bump the version in `pyproject.toml`, `uv.lock`, and `macos/Info.plist`.
 2. Merge the tested change to `main`.
-3. Tag that commit with the matching `v`-prefixed version, such as `v2.1.0`.
+3. Tag that commit with the matching `v`-prefixed version, such as `v2.1.1`.
 
 The release workflow rejects mismatched tags or a missing signing key, builds
 both Mac architectures, signs their appcasts, and publishes only after every

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hidemyemail_generator"
-version = "2.1.0"
+version = "2.1.1"
 description = "Generate and manage iCloud Hide My Email addresses"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -306,7 +306,7 @@ wheels = [
 
 [[package]]
 name = "hidemyemail-generator"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Prepare a corrected `v2.1.1` release so the native macOS downloads referenced by the README can be published successfully.

- Bump the Python package version from `2.1.0` to `2.1.1`.
- Keep the locked project metadata synchronized with the package version.
- Bump both macOS bundle version fields to `2.1.1`.
- Update the release documentation example to use the new tag.

Closes #58.

## Root cause

The README points macOS users to release assets named:

- `HideMyEmail-Generator-macOS-Apple-Silicon.dmg`
- `HideMyEmail-Generator-macOS-Intel.dmg`

GitHub currently resolves `releases/latest` to `v2.0.0`, but that release predates the native macOS app and contains neither DMG. The later `v2.1.0` release workflow attempted to build the app, but both macOS jobs failed under Xcode 16.4 before their artifacts could be uploaded. As a result, GitHub never created a `v2.1.0` release and the documented DMG URLs return 404.

The compiler compatibility fix is now present on `main`, but rerunning the existing `v2.1.0` workflow would still check out the old immutable tag and rebuild the same broken source snapshot. A new version and tag are required to run the release workflow from the corrected source.

## Changes

### Release metadata

- Set the project version in `pyproject.toml` to `2.1.1`.
- Set the local project package entry in `uv.lock` to `2.1.1`.
- Set `CFBundleShortVersionString` and `CFBundleVersion` in `macos/Info.plist` to `2.1.1`.

### Documentation

- Update the release instructions to use `v2.1.1` as the matching tag example.

## User impact

After this PR is merged and its commit is tagged `v2.1.1`, the existing release workflow can build and publish the Apple Silicon and Intel DMGs under the filenames already used by the README. The `releases/latest/download/...` links will then resolve to real macOS artifacts instead of the older `v2.0.0` release.

This PR does not move or rewrite the existing `v2.1.0` tag.

## Validation

- `uv lock --check` — passed
- `PYTHONPATH=src uv run --frozen pytest -q` — 11 passed
- `uv run --frozen ruff check` — passed
- macOS XCTest suite with Xcode beta — 16 passed
- `git diff --check` — passed
- ARM64 release-equivalent packaging with `scripts/build-macos-app.sh arm64` — passed
- Generated app bundle reports both short and build versions as `2.1.1`
- Generated app executable and bundled CLI helper are both ARM64
- Deep strict code-signature verification passed
- Generated `HideMyEmail-Generator-macOS-Apple-Silicon.dmg` using the exact filename referenced by the README

Local ARM64 artifact details:

- DMG size: `16,322,309` bytes
- DMG SHA-256: `265533a9ef159a2a1f3560a206b8bf72cb958947a871e6361c5ddd0d928b0bcf`
- ZIP size: `16,015,989` bytes
- ZIP SHA-256: `d01b3918ff24f5b87a83772347cccd507c05efd376a2bf30244854720e402852`

## Release follow-up

After merging:

1. Tag the merge commit as `v2.1.1`.
2. Push the tag to the upstream repository.
3. Confirm both architecture builds and protected signing jobs complete.
4. Confirm the release contains all nine expected assets, including both DMGs and both Sparkle appcasts.
5. Verify the README's `releases/latest/download/...` links return the published files.

Intel packaging, Sparkle signing, and final GitHub release publication remain GitHub Actions responsibilities because they require the Intel runner, protected release environment, and repository signing secret.
