### PR TITLE
feat(cli): manage existing Hide My Email addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,21 @@ uv run hidemyemail list --active --cookie-file cookies.txt
 uv run hidemyemail list --inactive --cookie-file cookies.txt
 ```
 
+### Manage an Address
+
+```bash
+uv run hidemyemail deactivate abc123@icloud.com
+uv run hidemyemail reactivate abc123@icloud.com
+uv run hidemyemail update-metadata abc123@icloud.com --label "Newsletter" --note "Signed up 2026-07"
+```
+
+Deactivating stops an address from forwarding mail without giving up the address;
+it stays on your account and can be reactivated later. `update-metadata` keeps
+whichever of `--label` / `--note` you leave out.
+
+Each command looks the address up by its email, so no identifier is needed. That
+costs one extra `list` call per invocation.
+
 ### Account Check
 
 ```bash

--- a/src/hidemyemail_generator/hidemyemail.py
+++ b/src/hidemyemail_generator/hidemyemail.py
@@ -129,3 +129,37 @@ class HideMyEmail:
         return await self._request_json(
             "GET", f"{self.base_url_v2}/list", params=self.params
         )
+
+    async def update_email_metadata(
+        self, anonymous_id: str, label: str, note: str
+    ) -> dict:
+        """Updates the label and note of a reserved email"""
+        payload = {
+            "anonymousId": anonymous_id,
+            "label": label,
+            "note": note,
+        }
+        return await self._request_json(
+            "POST",
+            f"{self.base_url_v1}/updateMetaData",
+            params=self.params,
+            json=payload,
+        )
+
+    async def deactivate_email(self, anonymous_id: str) -> dict:
+        """Deactivates an email so it stops forwarding"""
+        return await self._request_json(
+            "POST",
+            f"{self.base_url_v1}/deactivate",
+            params=self.params,
+            json={"anonymousId": anonymous_id},
+        )
+
+    async def reactivate_email(self, anonymous_id: str) -> dict:
+        """Reactivates a previously deactivated email"""
+        return await self._request_json(
+            "POST",
+            f"{self.base_url_v1}/reactivate",
+            params=self.params,
+            json={"anonymousId": anonymous_id},
+        )

--- a/src/hidemyemail_generator/main.py
+++ b/src/hidemyemail_generator/main.py
@@ -400,6 +400,7 @@ class RichHideMyEmail(HideMyEmail):
                         "label": row["label"],
                         "created_at": created_at,
                         "is_active": bool(row["isActive"]),
+                        "anonymous_id": row.get("anonymousId") or "",
                     }
                 )
                 self.table.add_row(
@@ -411,6 +412,87 @@ class RichHideMyEmail(HideMyEmail):
 
         self.console.print(self.table)
         return {"ok": True, "addresses": addresses, "error": None}
+
+    async def _resolve(self, email: str) -> Optional[dict]:
+        """Looks up the iCloud record for an address, needed for its anonymousId."""
+        gen_res = await self.list_email()
+        if not self._check_response(gen_res, "list emails"):
+            return None
+
+        for row in gen_res["result"]["hmeEmails"]:
+            if row.get("hme") != email:
+                continue
+            if not row.get("anonymousId"):
+                self.last_error = {
+                    "code": None,
+                    "message": f'iCloud returned no identifier for "{email}"',
+                    "retry_after": None,
+                }
+                self.console.log(f"[bold red][ERR][/] {self.last_error['message']}")
+                return None
+            return row
+
+        self.last_error = {
+            "code": None,
+            "message": f'No Hide My Email address matching "{email}"',
+            "retry_after": None,
+        }
+        self.console.log(
+            f'[bold red][ERR][/] {self.last_error["message"]} / 未找到匹配的隐藏邮箱'
+        )
+        return None
+
+    async def set_active(self, email: str, active: bool) -> dict:
+        self.last_error = None
+        row = await self._resolve(email)
+        if row is None:
+            return {"ok": False, "email": email, "is_active": None, "error": self.last_error}
+
+        action = "reactivate" if active else "deactivate"
+        call = self.reactivate_email if active else self.deactivate_email
+        res = await call(row["anonymousId"])
+        if not self._check_response(res, f"{action} email", email):
+            return {"ok": False, "email": email, "is_active": None, "error": self.last_error}
+
+        self.console.log(
+            f'[bold green][OK][/] "{email}" - Successfully {action}d / 操作成功'
+        )
+        return {"ok": True, "email": email, "is_active": active, "error": None}
+
+    async def update_metadata(
+        self, email: str, label: Optional[str], note: Optional[str]
+    ) -> dict:
+        self.last_error = None
+        row = await self._resolve(email)
+        if row is None:
+            return {
+                "ok": False,
+                "email": email,
+                "label": None,
+                "note": None,
+                "error": self.last_error,
+            }
+
+        new_label = label if label is not None else row.get("label") or ""
+        new_note = note if note is not None else row.get("note") or ""
+        res = await self.update_email_metadata(row["anonymousId"], new_label, new_note)
+        if not self._check_response(res, "update email metadata", email):
+            return {
+                "ok": False,
+                "email": email,
+                "label": None,
+                "note": None,
+                "error": self.last_error,
+            }
+
+        self.console.log(f'[bold green][OK][/] "{email}" - Metadata updated / 已更新')
+        return {
+            "ok": True,
+            "email": email,
+            "label": new_label,
+            "note": new_note,
+            "error": None,
+        }
 
 
 @click.group()
@@ -587,6 +669,96 @@ def capturecookiecommand(cookie_file: str, region: str):
 
     if not ok:
         raise click.ClickException("Could not capture the iCloud cookie")
+
+
+@click.command()
+@click.argument("email")
+@click.option(
+    "--cookie-file",
+    default=DEFAULT_COOKIE_FILENAME,
+    help="Path to cookie file / Cookie 文件路径",
+    type=click.Path(),
+)
+@click.option(
+    "--region",
+    default=DEFAULT_REGION,
+    show_default=True,
+    type=REGION_CHOICE,
+    help="iCloud region to use / iCloud 区域",
+)
+@click.option(
+    "--result-json",
+    type=click.Path(dir_okay=False),
+    help="Write a machine-readable result to this file",
+)
+def deactivatecommand(email: str, cookie_file: str, region: str, result_json: Optional[str]):
+    "Stop an address from forwarding mail / 停用隐藏邮箱转发"
+    _run_address_command(
+        _set_active(email, False, cookie_file, region), result_json
+    )
+
+
+@click.command()
+@click.argument("email")
+@click.option(
+    "--cookie-file",
+    default=DEFAULT_COOKIE_FILENAME,
+    help="Path to cookie file / Cookie 文件路径",
+    type=click.Path(),
+)
+@click.option(
+    "--region",
+    default=DEFAULT_REGION,
+    show_default=True,
+    type=REGION_CHOICE,
+    help="iCloud region to use / iCloud 区域",
+)
+@click.option(
+    "--result-json",
+    type=click.Path(dir_okay=False),
+    help="Write a machine-readable result to this file",
+)
+def reactivatecommand(email: str, cookie_file: str, region: str, result_json: Optional[str]):
+    "Resume forwarding for a deactivated address / 恢复已停用的隐藏邮箱"
+    _run_address_command(_set_active(email, True, cookie_file, region), result_json)
+
+
+@click.command()
+@click.argument("email")
+@click.option("--label", help="New label / 新标签")
+@click.option("--note", help="New note / 新备注")
+@click.option(
+    "--cookie-file",
+    default=DEFAULT_COOKIE_FILENAME,
+    help="Path to cookie file / Cookie 文件路径",
+    type=click.Path(),
+)
+@click.option(
+    "--region",
+    default=DEFAULT_REGION,
+    show_default=True,
+    type=REGION_CHOICE,
+    help="iCloud region to use / iCloud 区域",
+)
+@click.option(
+    "--result-json",
+    type=click.Path(dir_okay=False),
+    help="Write a machine-readable result to this file",
+)
+def updatemetadatacommand(
+    email: str,
+    label: Optional[str],
+    note: Optional[str],
+    cookie_file: str,
+    region: str,
+    result_json: Optional[str],
+):
+    "Change the label or note of an address / 修改隐藏邮箱的标签或备注"
+    if label is None and note is None:
+        raise click.UsageError("Provide --label and/or --note / 请提供 --label 或 --note")
+    _run_address_command(
+        _update_metadata(email, label, note, cookie_file, region), result_json
+    )
 
 
 @click.group(name="inbox")
@@ -1076,6 +1248,36 @@ async def _list(
         return await hme.list(label_query, active)
 
 
+def _run_address_command(coro, result_json: Optional[str]) -> None:
+    try:
+        result = asyncio.run(coro)
+    except KeyboardInterrupt:
+        coro.close()
+        return
+
+    write_result_json(result_json, result)
+    if not result["ok"]:
+        raise click.ClickException(result["error"]["message"])
+
+
+async def _set_active(
+    email: str, active: bool, cookie_file: str, region: str = DEFAULT_REGION
+) -> dict:
+    async with RichHideMyEmail(cookie_file=cookie_file, region=region) as hme:
+        return await hme.set_active(email, active)
+
+
+async def _update_metadata(
+    email: str,
+    label: Optional[str],
+    note: Optional[str],
+    cookie_file: str,
+    region: str = DEFAULT_REGION,
+) -> dict:
+    async with RichHideMyEmail(cookie_file=cookie_file, region=region) as hme:
+        return await hme.update_metadata(email, label, note)
+
+
 async def _whoami(cookie_file: str, region: str = DEFAULT_REGION) -> dict:
     console = Console()
     if not os.path.exists(cookie_file):
@@ -1315,6 +1517,9 @@ cli.add_command(listcommand, name="list")
 cli.add_command(generatecommand, name="generate")
 cli.add_command(whoamicommand, name="whoami")
 cli.add_command(capturecookiecommand, name="capture-cookie")
+cli.add_command(deactivatecommand, name="deactivate")
+cli.add_command(reactivatecommand, name="reactivate")
+cli.add_command(updatemetadatacommand, name="update-metadata")
 cli.add_command(inboxgroup)
 
 if __name__ == "__main__":

--- a/tests/test_address_management.py
+++ b/tests/test_address_management.py
@@ -1,0 +1,118 @@
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from hidemyemail_generator.main import RichHideMyEmail
+
+
+LIST_RESPONSE = {
+    "success": True,
+    "result": {
+        "hmeEmails": [
+            {
+                "anonymousId": "abc-123",
+                "hme": "example@icloud.com",
+                "label": "Example",
+                "note": "Original note",
+                "isActive": True,
+                "createTimestamp": 1753531200000,
+            }
+        ]
+    },
+}
+
+
+class FakeTransport:
+    """Records every request the client makes and replays canned responses."""
+
+    def __init__(self, responses=None):
+        self.calls = []
+        self.responses = responses or {}
+
+    async def __call__(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs.get("json")))
+        endpoint = url.rsplit("/", 1)[-1]
+        return self.responses.get(endpoint, {"success": True, "result": {}})
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class AddressManagementTests(unittest.TestCase):
+    def setUp(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        cookie_file = Path(tmpdir.name) / "cookies.txt"
+        cookie_file.write_text('X-APPLE-WEBAUTH-USER="v=1:s=0:d=1"', encoding="utf-8")
+
+        self.transport = FakeTransport({"list": LIST_RESPONSE})
+        patcher = patch.object(RichHideMyEmail, "_request_json", self.transport)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.hme = RichHideMyEmail(cookie_file=str(cookie_file))
+
+    def test_list_exposes_anonymous_id(self):
+        result = run(self.hme.list(None, True))
+        self.assertEqual(result["addresses"][0]["anonymous_id"], "abc-123")
+
+    def test_deactivate_posts_anonymous_id(self):
+        result = run(self.hme.set_active("example@icloud.com", False))
+        self.assertTrue(result["ok"])
+        self.assertFalse(result["is_active"])
+        method, url, payload = self.transport.calls[-1]
+        self.assertEqual(method, "POST")
+        self.assertTrue(url.endswith("/v1/hme/deactivate"))
+        self.assertEqual(payload, {"anonymousId": "abc-123"})
+
+    def test_reactivate_posts_anonymous_id(self):
+        result = run(self.hme.set_active("example@icloud.com", True))
+        self.assertTrue(result["ok"])
+        _, url, payload = self.transport.calls[-1]
+        self.assertTrue(url.endswith("/v1/hme/reactivate"))
+        self.assertEqual(payload, {"anonymousId": "abc-123"})
+
+    def test_update_metadata_keeps_unspecified_fields(self):
+        result = run(self.hme.update_metadata("example@icloud.com", "Renamed", None))
+        self.assertTrue(result["ok"])
+        _, url, payload = self.transport.calls[-1]
+        self.assertTrue(url.endswith("/v1/hme/updateMetaData"))
+        self.assertEqual(
+            payload,
+            {"anonymousId": "abc-123", "label": "Renamed", "note": "Original note"},
+        )
+
+    def test_unknown_address_fails_without_mutating(self):
+        result = run(self.hme.set_active("nope@icloud.com", False))
+        self.assertFalse(result["ok"])
+        self.assertIn("nope@icloud.com", result["error"]["message"])
+        self.assertEqual(len(self.transport.calls), 1)
+
+    def test_missing_anonymous_id_fails_without_mutating(self):
+        self.transport.responses["list"] = {
+            "success": True,
+            "result": {
+                "hmeEmails": [
+                    {"hme": "example@icloud.com", "label": "", "isActive": True}
+                ]
+            },
+        }
+        result = run(self.hme.set_active("example@icloud.com", False))
+        self.assertFalse(result["ok"])
+        self.assertIn("no identifier", result["error"]["message"])
+        self.assertEqual(len(self.transport.calls), 1)
+
+    def test_failed_list_surfaces_error(self):
+        self.transport.responses["list"] = {
+            "success": False,
+            "error": {"errorCode": "-41015", "errorMessage": "Too many requests"},
+        }
+        result = run(self.hme.update_metadata("example@icloud.com", "x", None))
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error"]["code"], "-41015")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Brings the CLI up to parity with the Android app on address management.

## What was missing

Android talks to six HME endpoints; the Python client only knew three:

| Endpoint | Android | CLI (before) |
|---|---|---|
| `/v1/hme/generate` | ✅ | ✅ |
| `/v1/hme/reserve` | ✅ | ✅ |
| `/v2/hme/list` | ✅ | ✅ |
| `/v1/hme/updateMetaData` | ✅ | ❌ |
| `/v1/hme/deactivate` | ✅ | ❌ |
| `/v1/hme/reactivate` | ✅ | ❌ |

So there was no way to stop an address forwarding, turn it back on, or rename it
from the CLI — or from the macOS app, which bridges through the CLI.

## Changes

- `hidemyemail.py`: `update_email_metadata()`, `deactivate_email()`, `reactivate_email()`.
- `main.py`: `deactivate`, `reactivate`, and `update-metadata` commands, each with
  `--cookie-file` / `--region` / `--result-json` to match the existing commands.
- `list` now carries `anonymous_id` in its result payload. All three endpoints key
  off it and the parser was dropping it.

Commands take the email address, not the `anonymousId`, and resolve it via a
`list` call — one extra request per invocation, but nobody has to go find an
opaque identifier first. Resolution failures (unknown address, or a record with
no `anonymousId`) abort before any mutating request is sent.

`update-metadata` sends both `label` and `note` because the endpoint replaces
both; whichever flag you omit is carried over from the current record. Passing
neither is a usage error rather than a no-op round trip.

## Testing

New `tests/test_address_management.py` asserts endpoint URL and JSON payload
shape for each of the three calls, label/note carry-over, and that both
resolution failure modes stop before mutating. `uv run pytest` → 18 passed.
`uv run ruff check` clean.

Not included, happy to split out if wanted: no macOS UI is wired to these yet
(the bridge can call them, nothing does), and `inbox sync-hme` still doesn't
persist `anonymous_id` to the local DB.