### PR TITLE
chore: sync request headers and client values with the iCloud web client

### DIFF
--- a/android/app/src/main/java/com/hidemyemail/generator/MainActivity.kt
+++ b/android/app/src/main/java/com/hidemyemail/generator/MainActivity.kt
@@ -107,6 +107,9 @@ object HmeEndpoints {
 object HmeRequestDefaults {
     const val clientBuildNumber = "2626Build17"
     const val clientMasteringNumber = "2626Build17"
+    const val userAgent =
+        "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Mobile Safari/537.36"
+    const val secChUa = "\"Not;A=Brand\";v=\"8\", \"Chromium\";v=\"150\", \"Google Chrome\";v=\"150\""
 }
 
 enum class ICloudRegion(
@@ -1330,7 +1333,9 @@ internal class HmeRepository(
             .build()
         val builder = baseRequest(httpUrl.toString(), cookie, region)
         if (method == "POST") {
-            val body = (payload ?: JSONObject()).toString().toRequestBody("application/json".toMediaType())
+            // text/plain matches the iCloud web client; OkHttp derives Content-Type from the body,
+            // so setting it here rather than as a header is what actually reaches Apple.
+            val body = (payload ?: JSONObject()).toString().toRequestBody("text/plain".toMediaType())
             builder.post(body)
         } else {
             builder.get()
@@ -1345,12 +1350,19 @@ internal class HmeRepository(
             .header("Connection", "keep-alive")
             .header("Pragma", "no-cache")
             .header("Cache-Control", "no-cache")
-            .header("User-Agent", "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/141.0.0.0 Mobile Safari/537.36")
-            .header("Content-Type", "application/json")
+            .header("User-Agent", HmeRequestDefaults.userAgent)
+            .header("Content-Type", "text/plain")
             .header("Accept", "*/*")
+            .header("Sec-GPC", "1")
             .header("Origin", region.origin)
+            .header("Sec-Fetch-Site", "same-site")
+            .header("Sec-Fetch-Mode", "cors")
+            .header("Sec-Fetch-Dest", "empty")
             .header("Referer", "${region.origin}/")
             .header("Accept-Language", acceptLanguage(region))
+            .header("sec-ch-ua", HmeRequestDefaults.secChUa)
+            .header("sec-ch-ua-mobile", "?1")
+            .header("sec-ch-ua-platform", "\"Android\"")
             .header("Cookie", cookie.trim())
     }
 
@@ -1428,7 +1440,7 @@ internal class HmeRepository(
 
         fun acceptLanguage(region: ICloudRegion): String {
             return when (region) {
-                ICloudRegion.Global -> "en-US,en;q=0.9"
+                ICloudRegion.Global -> "en-US,en;q=0.7"
                 ICloudRegion.China -> "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7"
             }
         }

--- a/android/app/src/test/java/com/hidemyemail/generator/RegionProtocolTest.kt
+++ b/android/app/src/test/java/com/hidemyemail/generator/RegionProtocolTest.kt
@@ -12,7 +12,7 @@ class RegionProtocolTest {
 
     @Test
     fun usesRegionAppropriateAcceptLanguage() {
-        assertEquals("en-US,en;q=0.9", HmeRepository.acceptLanguage(ICloudRegion.Global))
+        assertEquals("en-US,en;q=0.7", HmeRepository.acceptLanguage(ICloudRegion.Global))
         assertEquals("zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7", HmeRepository.acceptLanguage(ICloudRegion.China))
     }
 

--- a/src/hidemyemail_generator/hidemyemail.py
+++ b/src/hidemyemail_generator/hidemyemail.py
@@ -13,18 +13,48 @@ class HideMyEmail:
         "global": {
             "maildomain_host": "p68-maildomainws.icloud.com",
             "web_origin": "https://www.icloud.com",
+            "accept_language": "en-US,en;q=0.7",
+            "lang_code": "en-us",
         },
         "china": {
             "maildomain_host": "p217-maildomainws.icloud.com.cn",
             "web_origin": "https://www.icloud.com.cn",
+            "accept_language": "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7",
+            "lang_code": "zh-cn",
         },
     }
     params = {
-        "clientBuildNumber": "2536Project32",
-        "clientMasteringNumber": "2536B20",
+        "clientBuildNumber": "2626Build17",
+        "clientMasteringNumber": "2626Build17",
         "clientId": "",
         "dsid": "",  # Directory Services Identifier (DSID) is a method of identifying AppleID accounts
     }
+    USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
+    SEC_CH_UA = '"Not;A=Brand";v="8", "Chromium";v="150", "Brave";v="150"'
+
+    @classmethod
+    def browser_headers(cls, region: str, cookies: str = "") -> dict:
+        """Headers mimicking the iCloud web client, shared by every request we send."""
+        config = cls.REGION_CONFIG[region]
+        return {
+            "Connection": "keep-alive",
+            "Pragma": "no-cache",
+            "Cache-Control": "no-cache",
+            "User-Agent": cls.USER_AGENT,
+            "Content-Type": "text/plain",
+            "Accept": "*/*",
+            "Sec-GPC": "1",
+            "Origin": config["web_origin"],
+            "Sec-Fetch-Site": "same-site",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Dest": "empty",
+            "Referer": f"{config['web_origin']}/",
+            "Accept-Language": config["accept_language"],
+            "sec-ch-ua": cls.SEC_CH_UA,
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": '"macOS"',
+            "Cookie": cookies.strip(),
+        }
 
     def __init__(
         self, cookies: str = "", region: str = "global", maildomain_host: str = ""
@@ -42,7 +72,9 @@ class HideMyEmail:
         resolved_maildomain_host = maildomain_host or config["maildomain_host"]
         self.base_url_v1 = f"https://{resolved_maildomain_host}/v1/hme"
         self.base_url_v2 = f"https://{resolved_maildomain_host}/v2/hme"
+        self.region = region
         self.web_origin = config["web_origin"]
+        self.lang_code = config["lang_code"]
         self.cookies = cookies
 
     async def __aenter__(self):
@@ -50,25 +82,7 @@ class HideMyEmail:
             ssl_context=ssl.create_default_context(cafile=certifi.where())
         )
         self.s = aiohttp.ClientSession(
-            headers={
-                "Connection": "keep-alive",
-                "Pragma": "no-cache",
-                "Cache-Control": "no-cache",
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
-                "Content-Type": "text/plain",
-                "Accept": "*/*",
-                "Sec-GPC": "1",
-                "Origin": self.web_origin,
-                "Sec-Fetch-Site": "same-site",
-                "Sec-Fetch-Mode": "cors",
-                "Sec-Fetch-Dest": "empty",
-                "Referer": f"{self.web_origin}/",
-                "Accept-Language": "en-US,en-GB;q=0.9,en;q=0.8,cs;q=0.7",
-                "sec-ch-ua": '"Brave";v="141", "Not?A_Brand";v="8", "Chromium";v="141"',
-                "sec-ch-ua-mobile": "?0",
-                "sec-ch-ua-platform": '"macOS"',
-                "Cookie": self.__cookies.strip(),
-            },
+            headers=self.browser_headers(self.region, self.__cookies),
             timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_SECONDS),
             connector=connector,
         )
@@ -110,7 +124,7 @@ class HideMyEmail:
             "POST",
             f"{self.base_url_v1}/generate",
             params=self.params,
-            json={"langCode": "en-us"},
+            json={"langCode": self.lang_code},
         )
 
     async def reserve_email(self, email: str, label: str, note: str) -> dict:

--- a/src/hidemyemail_generator/main.py
+++ b/src/hidemyemail_generator/main.py
@@ -201,13 +201,7 @@ async def fetch_account_info(cookie_file: str, region: str) -> dict:
 async def fetch_account_info_from_cookie(
     cookie: str, region: str, maildomain_host: str = ""
 ) -> dict:
-    headers = {
-        "Cookie": cookie,
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
-        "Origin": HideMyEmail.REGION_CONFIG[region]["web_origin"],
-        "Referer": f"{HideMyEmail.REGION_CONFIG[region]['web_origin']}/",
-        "Accept": "*/*",
-    }
+    headers = HideMyEmail.browser_headers(region, cookie)
     connector = aiohttp.TCPConnector(
         ssl_context=ssl.create_default_context(cafile=certifi.where())
     )

--- a/tests/test_request_protocol.py
+++ b/tests/test_request_protocol.py
@@ -1,0 +1,63 @@
+import asyncio
+import unittest
+from unittest.mock import patch
+
+from hidemyemail_generator.hidemyemail import HideMyEmail
+
+
+# Mirrors the iCloud web client request the values were captured from. Update
+# this together with HideMyEmail when Apple ships a new web client.
+CAPTURED_HEADERS = {
+    "Connection": "keep-alive",
+    "Pragma": "no-cache",
+    "Cache-Control": "no-cache",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36",
+    "Content-Type": "text/plain",
+    "Accept": "*/*",
+    "Sec-GPC": "1",
+    "Origin": "https://www.icloud.com",
+    "Sec-Fetch-Site": "same-site",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Dest": "empty",
+    "Referer": "https://www.icloud.com/",
+    "Accept-Language": "en-US,en;q=0.7",
+    "sec-ch-ua": '"Not;A=Brand";v="8", "Chromium";v="150", "Brave";v="150"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"macOS"',
+}
+
+
+class RequestProtocolTests(unittest.TestCase):
+    def test_global_headers_match_captured_web_client(self):
+        headers = HideMyEmail.browser_headers("global", "cookie=value")
+        self.assertEqual({k: v for k, v in headers.items() if k != "Cookie"}, CAPTURED_HEADERS)
+        self.assertEqual(headers["Cookie"], "cookie=value")
+
+    def test_client_version_matches_captured_request(self):
+        self.assertEqual(HideMyEmail.params["clientBuildNumber"], "2626Build17")
+        self.assertEqual(HideMyEmail.params["clientMasteringNumber"], "2626Build17")
+
+    def test_china_region_swaps_origin_and_locale(self):
+        headers = HideMyEmail.browser_headers("china")
+        self.assertEqual(headers["Origin"], "https://www.icloud.com.cn")
+        self.assertEqual(headers["Referer"], "https://www.icloud.com.cn/")
+        self.assertEqual(headers["Accept-Language"], "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7")
+
+    def test_cookie_whitespace_is_stripped(self):
+        self.assertEqual(HideMyEmail.browser_headers("global", "  a=b\n")["Cookie"], "a=b")
+
+    def test_generate_sends_region_lang_code(self):
+        seen = []
+
+        async def fake_request(self, method, url, **kwargs):
+            seen.append(kwargs.get("json"))
+            return {"success": True, "result": {}}
+
+        for region, expected in [("global", "en-us"), ("china", "zh-cn")]:
+            with patch.object(HideMyEmail, "_request_json", fake_request):
+                asyncio.run(HideMyEmail(region=region).generate_email())
+            self.assertEqual(seen[-1], {"langCode": expected})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refreshes the values that impersonate Apple's web client against a current
capture, and collapses the three copies of the header set that let them drift.

## Stale values

| Value | Before | After |
|---|---|---|
| `clientBuildNumber` | `2536Project32` | `2626Build17` |
| `clientMasteringNumber` | `2536B20` | `2626Build17` |
| `User-Agent` (macOS) | Chrome 141 | Chrome 150 |
| `User-Agent` (Android) | Chrome 141 | Chrome 150 |
| `sec-ch-ua` | `"Brave";v="141", "Not?A_Brand";v="8", …` | `"Not;A=Brand";v="8", "Chromium";v="150", …` |
| `Accept-Language` (global) | `en-US,en-GB;q=0.9,en;q=0.8,cs;q=0.7` | `en-US,en;q=0.7` |

Android already had the current build numbers; the CLI was two versions behind.
Per the maintenance note in CLAUDE.md, these going stale is the usual cause of
non-auth generation failures.

## Deduplication

The header set existed in three places and each had drifted:

1. `HideMyEmail.__aenter__` — complete.
2. `fetch_account_info_from_cookie` in `main.py` — sent only 5 of 17 headers,
   missing the entire `Sec-Fetch-*` / `Sec-GPC` / client-hints block, so
   `whoami` and cookie capture had a visibly different fingerprint from every
   other request.
3. Android `baseRequest` — same gap.

All three now build from `HideMyEmail.browser_headers(region, cookie)` /
`HmeRequestDefaults`. Adding a header in one place no longer means remembering
two others.

## Region correctness

`Accept-Language` and the `generate` `langCode` are derived from the region
instead of hardcoded. The CLI previously sent `langCode: en-us` even under
`--region china`; Android already did this correctly.

## Android Content-Type bug

`baseRequest` set `Content-Type: text/plain` as a header but handed OkHttp a
body built with `"application/json".toMediaType()`. OkHttp's `BridgeInterceptor`
overwrites the header from the body's media type, so Android has been sending
`application/json` where the web client sends `text/plain`. Fixed at the body,
which is the part that actually reaches Apple.

## Not changed

`clientId` and `dsid` stay empty. The capture has real values for both, but
they identify a specific account and the empty strings work today, so this
isn't the PR to start sending an install identifier.

## Testing

New `tests/test_request_protocol.py` pins the full global header set against
the capture, plus region origin/locale swapping and the per-region `langCode`.
`uv run pytest` → 16 passed, `uv run ruff check` clean.

Android's `RegionProtocolTest` updated for the new `Accept-Language`. **I could
not run the Android tests locally** — no JVM or Android SDK in this environment
— so `testDebugUnitTest` and `assembleDebug` need to go green in CI before merge.