### PR TITLE
ci(android): concurrency group, tighter path filter, single Gradle run

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -5,20 +5,21 @@ on:
     paths:
       - 'android/**'
       - '.github/workflows/android-ci.yml'
-      - '.gitignore'
-      - 'README.md'
-      - 'README.zh-CN.md'
   push:
     branches: [main]
     paths:
       - 'android/**'
       - '.github/workflows/android-ci.yml'
-      - '.gitignore'
-      - 'README.md'
-      - 'README.zh-CN.md'
 
 permissions:
   contents: read
+
+# Superseded PR runs are cancelled; pushes to main are not — post-merge runs are
+# the only place two independently-reviewed PRs get built together, and they
+# publish the APK artifact.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test-and-build:
@@ -39,10 +40,8 @@ jobs:
           cache: gradle
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
-      - name: Run Android unit tests
-        run: bash ./gradlew testDebugUnitTest --no-daemon --stacktrace
-      - name: Assemble debug APK
-        run: bash ./gradlew assembleDebug --no-daemon --stacktrace
+      - name: Test and assemble debug APK
+        run: bash ./gradlew testDebugUnitTest assembleDebug --no-daemon --stacktrace
       - name: Upload unit test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -50,6 +49,7 @@ jobs:
           name: android-unit-test-results
           path: android/app/build/test-results/testDebugUnitTest/
           if-no-files-found: ignore
+          retention-days: 7
       - name: Upload debug APK
         if: success()
         uses: actions/upload-artifact@v4
@@ -57,3 +57,4 @@ jobs:
           name: HideMyEmail-Android-debug
           path: android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
Cuts wasted GitHub Actions minutes on the workflow that runs most often. No coverage is lost — the job still runs `testDebugUnitTest` and `assembleDebug` on every change that can affect them.

### Concurrency group
There was no `concurrency:` key, so every push to a PR branch started a full Android SDK + Gradle build and superseded runs ran to completion.

`cancel-in-progress` is deliberately scoped to `pull_request` only. Post-merge runs on `main` are the only place two independently-reviewed PRs get built *together*, and they publish the APK artifact — those should never be cancelled.

### Path filter
Both triggers listed `.gitignore`, `README.md` and `README.zh-CN.md`. The job never reads any of them.

This is live waste, not theory: **#61** changed zero Android files, touched `README.md`, and ran the full Android build twice (PR + merge). The filter was also inconsistent rather than deliberate — `README.ru.md` exists in the repo but was never listed.

### One Gradle invocation
```diff
-      - run: bash ./gradlew testDebugUnitTest --no-daemon --stacktrace
-      - run: bash ./gradlew assembleDebug --no-daemon --stacktrace
+      - run: bash ./gradlew testDebugUnitTest assembleDebug --no-daemon --stacktrace
```
With `--no-daemon` the old form paid JVM startup + Gradle configuration twice. If tests fail, assemble is skipped either way, and the `if: always()` test-results upload is unaffected.

### Artifact retention
Both uploads used the default 90-day retention for a debug APK and test XML produced on every PR and every main push. Now `retention-days: 7`. Storage quota rather than runner minutes, but free.

### Validation
No Android SDK available locally, so the Gradle invocation wasn't run on this machine — but this PR touches `.github/workflows/android-ci.yml`, which is still in the path filter, so CI exercises the merged invocation on this PR itself.