### PR TITLE
ci(release): sign both macOS arches on a single runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,85 +136,85 @@ jobs:
           path: build/unsigned-${{ matrix.arch }}/
           if-no-files-found: error
 
+  # Sparkle's generate_appcast / sign_update / BinaryDelta are universal
+  # binaries, and signing is over the archive bytes — the tool's architecture
+  # need not match the app's. One arm64 runner therefore signs both arches
+  # instead of provisioning two macOS runners for shell work.
   sign:
     needs: macos
     environment: release
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: macos-15
-            arch: arm64
-            cli_asset: hidemyemail-macos
-            app_label: Apple-Silicon
-          - runner: macos-15-intel
-            arch: x86_64
-            cli_asset: hidemyemail-macos-x86_64
-            app_label: Intel
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-15
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: unsigned-macos-${{ matrix.arch }}
+          pattern: unsigned-macos-*
           path: unsigned
 
-      - name: Generate signed appcast
+      - name: Generate signed appcasts
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         shell: bash
         run: |
-          updates="build/appcast-${{ matrix.arch }}"
-          archive="HideMyEmail-Generator-macOS-${{ matrix.app_label }}.zip"
-          tools="unsigned/tools"
+          tools="unsigned/unsigned-macos-arm64/tools"
           chmod +x \
             "$tools/BinaryDelta" \
             "$tools/generate_appcast" \
             "$tools/sign_update"
-          mkdir -p "$updates" dist
-          cp "unsigned/$archive" "$updates/$archive"
+          mkdir -p dist
 
-          printf '%s' "$SPARKLE_PRIVATE_KEY" \
-            | "$tools/generate_appcast" \
-                --ed-key-file - \
-                --download-url-prefix \
-                  "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/" \
-                --link "https://github.com/${GITHUB_REPOSITORY}" \
-                --maximum-deltas 0 \
-                -o "$updates/appcast-${{ matrix.arch }}.xml" \
-                "$updates"
+          for arch in arm64 x86_64; do
+            case "$arch" in
+              arm64) app_label=Apple-Silicon; cli_asset=hidemyemail-macos ;;
+              x86_64) app_label=Intel; cli_asset=hidemyemail-macos-x86_64 ;;
+            esac
 
-          cp "$updates/appcast-${{ matrix.arch }}.xml" dist/
-          appcast="dist/appcast-${{ matrix.arch }}.xml"
-          signature="$(sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p' "$appcast")"
-          test -n "$signature"
-          grep -Fq "/releases/download/${GITHUB_REF_NAME}/$archive" \
-            "$appcast"
-          printf '%s' "$SPARKLE_PRIVATE_KEY" \
-            | "$tools/sign_update" --verify --ed-key-file - \
-                "$updates/$archive" "$signature"
+            unsigned="unsigned/unsigned-macos-$arch"
+            updates="build/appcast-$arch"
+            archive="HideMyEmail-Generator-macOS-$app_label.zip"
+            mkdir -p "$updates"
+            cp "$unsigned/$archive" "$updates/$archive"
 
-          invalid_signature="${signature%?}A"
-          if printf '%s' "$SPARKLE_PRIVATE_KEY" \
-            | "$tools/sign_update" --verify --ed-key-file - \
-                "$updates/$archive" "$invalid_signature" >/dev/null 2>&1; then
-            echo "Sparkle accepted an invalid update signature." >&2
-            exit 1
-          fi
+            printf '%s' "$SPARKLE_PRIVATE_KEY" \
+              | "$tools/generate_appcast" \
+                  --ed-key-file - \
+                  --download-url-prefix \
+                    "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/" \
+                  --link "https://github.com/${GITHUB_REPOSITORY}" \
+                  --maximum-deltas 0 \
+                  -o "$updates/appcast-$arch.xml" \
+                  "$updates"
 
-          cp \
-            "unsigned/${{ matrix.cli_asset }}" \
-            "unsigned/HideMyEmail-Generator-macOS-${{ matrix.app_label }}.zip" \
-            "unsigned/HideMyEmail-Generator-macOS-${{ matrix.app_label }}.dmg" \
-            dist/
+            cp "$updates/appcast-$arch.xml" dist/
+            appcast="dist/appcast-$arch.xml"
+            signature="$(sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p' "$appcast")"
+            test -n "$signature"
+            grep -Fq "/releases/download/${GITHUB_REF_NAME}/$archive" \
+              "$appcast"
+            printf '%s' "$SPARKLE_PRIVATE_KEY" \
+              | "$tools/sign_update" --verify --ed-key-file - \
+                  "$updates/$archive" "$signature"
+
+            invalid_signature="${signature%?}A"
+            if printf '%s' "$SPARKLE_PRIVATE_KEY" \
+              | "$tools/sign_update" --verify --ed-key-file - \
+                  "$updates/$archive" "$invalid_signature" >/dev/null 2>&1; then
+              echo "Sparkle accepted an invalid update signature for $arch." >&2
+              exit 1
+            fi
+
+            cp \
+              "$unsigned/$cli_asset" \
+              "$unsigned/HideMyEmail-Generator-macOS-$app_label.zip" \
+              "$unsigned/HideMyEmail-Generator-macOS-$app_label.dmg" \
+              dist/
+          done
+
+          test "$(find dist -maxdepth 1 -type f | wc -l)" -eq 8
 
       - uses: actions/upload-artifact@v4
         with:
-          name: release-macos-${{ matrix.arch }}
-          path: |
-            dist/${{ matrix.cli_asset }}
-            dist/HideMyEmail-Generator-macOS-${{ matrix.app_label }}.zip
-            dist/HideMyEmail-Generator-macOS-${{ matrix.app_label }}.dmg
-            dist/appcast-${{ matrix.arch }}.xml
+          name: release-macos
+          path: dist/
           if-no-files-found: error
 
   release:


### PR DESCRIPTION
The `sign` job provisioned **two** macOS runners (`macos-15` + `macos-15-intel`) whose only work is shell plus Sparkle's `generate_appcast` / `sign_update` / `BinaryDelta`, downloaded as artifacts from the `macos` job. macOS runners bill at 10x Linux, so this was the most expensive runner usage in the repo — and half of it was avoidable.

Collapsed to a single `macos-15` runner that signs both arches in a loop.

### Why this is safe
Signing is an ed25519 signature over the archive **bytes** — the architecture of the signing tool has no bearing on the architecture of the app being signed. And the tools are universal binaries anyway, so no Rosetta is involved. Verified against the exact pinned version (`Package.resolved` → Sparkle 2.9.4):

```
generate_appcast: x86_64 arm64
sign_update:      x86_64 arm64
BinaryDelta:      x86_64 arm64
```

### Verification
Beyond the `lipo` check, I ran the rewritten script end-to-end on an arm64 machine against a fixture: two minimal `.app` bundles (Apple-Silicon / Intel labels) zipped with `ditto`, a matched ed25519 keypair, and the real Sparkle 2.9.4 binaries with their exec bits stripped to mimic an artifact download.

```
Wrote 1 new update ... in appcast-arm64.xml
>>> arm64 signed OK
Wrote 1 new update ... in appcast-x86_64.xml
>>> x86_64 signed OK
SCRIPT OK
```

Both appcasts came out with distinct valid `sparkle:edSignature` values and the correct per-arch `releases/download/v2.1.1/...` URLs, the `--verify` round-trip passed for each, and the tampered-signature guard still trips (Sparkle rejects `${signature%?}A`). All 8 macOS files were produced.

### Artifact plumbing
`release-macos-arm64` + `release-macos-x86_64` become one `release-macos` holding all 8 files. The `release` job downloads with `pattern: release-*` and `merge-multiple: true`, so `test ... -eq 9` (8 macOS + 1 Windows exe) and both `appcast-*.xml` assertions are unaffected.

Added `test "$(find dist -maxdepth 1 -type f | wc -l)" -eq 8` in the sign job. The old per-arch upload listed its 4 files explicitly with `if-no-files-found: error`; uploading `dist/` wholesale would have lost that check, and the count assertion restores it — a partial dist now fails in `sign` rather than at release time.

### Two things I deliberately did *not* change
**`fail-fast: false` on the `macos` matrix — kept.** The argument for flipping it is real: a release needs all 9 assets, so once arm64 fails, Intel is burning a 10x runner for a release that cannot ship. But cancelling the surviving leg only defers its failure — you fix arm64, re-tag, and pay for *both* arches again to discover Intel was broken too. Since this is tag-triggered and only wastes anything when a release build breaks, seeing both failures in one run is cheaper than serializing them across re-tags. (The `sign` matrix's `fail-fast` is moot — that matrix is gone.)

**No `concurrency:` key.** This workflow is tag-triggered, so runs are never superseded.

Companion PR for the everyday win: #64 (Android CI).