### PR TITLE
fix(macos): build with Xcode 26 so actool can compile the icon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Test app
         run: |
           cd macos
-          xcodebuild test \
+          DEVELOPER_DIR="$(../scripts/xcode-developer-dir.sh)" xcodebuild test \
             -scheme HideMyEmailGenerator \
             -destination "platform=macOS,arch=${{ matrix.arch }}" \
             -derivedDataPath "$PWD/../build/macos-app-${{ matrix.arch }}/xcode" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,13 @@ Run the macOS Swift tests with `xcodebuild` after changing the app.
 
 ### macOS build artifacts
 
+**Xcode 26 or newer is required.** `HME-Gen-icon.icon` is an Icon Composer
+document and only `actool` from Xcode 26 onwards can compile it. The build picks
+an Xcode via `scripts/xcode-developer-dir.sh` (first `/Applications` Xcode with
+major version >= 26, or an explicit `DEVELOPER_DIR`) rather than trusting the
+`/Applications/Xcode.app` symlink, which on the GitHub runners points at 16.4.
+Anything older fails with a clear error instead of building.
+
 After every change under `macos/Sources/`, run
 `scripts/build-macos-app.sh "$(uname -m)"` before handing off the work. The
 script removes and regenerates `build/macos-app-$ARCH` and the matching macOS

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -19,13 +19,7 @@ if [[ "$(uname -m)" != "$ARCH" ]]; then
   exit 1
 fi
 
-if [[ -z "${DEVELOPER_DIR:-}" ]]; then
-  if [[ -d /Applications/Xcode.app/Contents/Developer ]]; then
-    DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
-  else
-    DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
-  fi
-fi
+DEVELOPER_DIR="$("$ROOT/scripts/xcode-developer-dir.sh")"
 VERSION="${VERSION:-$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$ROOT/pyproject.toml" | head -1)}"
 SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-$DEFAULT_FEED_URL}"
 BUILD_ROOT="$ROOT/build/macos-app-$ARCH"

--- a/scripts/xcode-developer-dir.sh
+++ b/scripts/xcode-developer-dir.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# HME-Gen-icon.icon is an Icon Composer document, which only actool from Xcode 26
+# onwards can compile. The macOS runner images ship Xcode 26 but keep
+# /Applications/Xcode.app pointed at 16.4, so resolve a qualifying Xcode instead
+# of trusting the default symlink.
+MIN_XCODE_MAJOR=26
+
+if [[ -n "${DEVELOPER_DIR:-}" ]]; then
+  echo "$DEVELOPER_DIR"
+  exit 0
+fi
+
+shopt -s nullglob
+for app in /Applications/Xcode.app /Applications/Xcode-beta.app /Applications/Xcode_*.app; do
+  [[ -d "$app/Contents/Developer" ]] || continue
+  major="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
+    "$app/Contents/version.plist" 2>/dev/null | cut -d. -f1)"
+  if [[ "${major:-0}" -ge "$MIN_XCODE_MAJOR" ]]; then
+    echo "$app/Contents/Developer"
+    exit 0
+  fi
+done
+
+echo "Xcode $MIN_XCODE_MAJOR or newer is required to compile HME-Gen-icon.icon; none found in /Applications." >&2
+exit 1


### PR DESCRIPTION
Fixes #63.

### Root cause
Confirmed the diagnosis in the issue. `HME-Gen-icon.icon` is an Icon Composer document — `icon.json` carries `glass` layers and `extended-srgb` gradients, the Liquid Glass format introduced with Xcode 26 — so only Xcode 26's `actool` can compile it.

`build-macos-app.sh` preferred `/Applications/Xcode.app`, and the runner images point that symlink at 16.4.

### The fix is smaller than either option in the issue
The issue proposed moving to a runner image with Xcode 26, or dropping `actool` entirely. Neither is necessary — **the macos-15 images already ship Xcode 26**, they just don't make it the default:

```
| 26.3           | 17C529 | /Applications/Xcode_26.3.app   |
| 26.2           | 17C52  | /Applications/Xcode_26.2.app   |
| 26.1.1         | 17B100 | /Applications/Xcode_26.1.1.app |
| 26.0.1         | 17A400 | /Applications/Xcode_26.0.1.app |
| 16.4 (default) | 16F6   | /Applications/Xcode_16.4.app   | ... /Applications/Xcode.app |
```

Identical tables in both `macos-15-Readme.md` and `macos-15-arm64-Readme.md`, so this holds for the Intel runner too — which was the open question in the issue. No runner image migration, no change to the OS the binaries are built against, no `.icns` toolchain rewrite.

### Change
Xcode resolution moves into `scripts/xcode-developer-dir.sh`: pick the first Xcode with major ≥ 26, honour an explicit `DEVELOPER_DIR`, and **error out if none qualifies**. That last part replaces a real trap — the old code fell back to `/Applications/Xcode-beta.app/Contents/Developer` without checking it exists, so a machine with neither got an obscure failure deep into the build instead of a clear message up front.

It's a shared script rather than inline logic because `release.yml`'s `Test app` step needs the same answer: it passes `-derivedDataPath` pointing at the directory `build-macos-app.sh` just populated. Leaving the test on the default 16.4 while the build used 26 would put two toolchains in one derived data directory.

### Validation — please read
**I could not run the actual build.** This machine has only Command Line Tools (`xcode-select -p` → `/Library/Developer/CommandLineTools`, no `Xcode.app` anywhere per Spotlight), and `actool` ships only inside Xcode. The `actool` invocation itself is unchanged by this PR, but I want to be clear that "icon now compiles" is inferred from the Xcode version requirement, not observed.

What I did verify: the selection logic, against six simulated `/Applications` layouts.

| Scenario | Result |
|---|---|
| macos-15 runner (16.4 default + 26.x present) | picks `Xcode_26.0.1.app` — **the bug case** |
| macos-26 runner (26.5 default) | picks `Xcode.app`, no churn |
| Local dev, only `Xcode-beta.app` (27.0) | picks the beta |
| Only Xcode 16 installed | fails with a clear message |
| No Xcode at all | fails with a clear message |
| `DEVELOPER_DIR` preset | respected, unchanged |

It selects the *oldest* qualifying Xcode (26.0.1 rather than 26.3) — deterministic per image, and closest to the minimum the script claims to support.

### Note on ordering
This unblocks #65 as a side effect. `macos` currently fails on both arches, so `sign` is skipped — meaning the collapsed single-runner sign job from #65 has never executed in CI. The next successful tag after this merges will be the first live run of both changes.