### PR TITLE
ci(release): build on macOS 26, allow test runs without a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: Release
 
+# workflow_dispatch builds and tests everything but signs nothing and publishes
+# nothing, so the expensive macOS path can be exercised from a branch without
+# spending a version number on a tag that might not ship.
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -20,6 +24,7 @@ jobs:
           enable-cache: true
 
       - name: Validate version
+        if: github.ref_type == 'tag'
         shell: bash
         run: |
           version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml | head -1)"
@@ -64,11 +69,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-15
+          - runner: macos-26
             arch: arm64
             cli_asset: hidemyemail-macos
             app_label: Apple-Silicon
-          - runner: macos-15-intel
+          - runner: macos-26-intel
             arch: x86_64
             cli_asset: hidemyemail-macos-x86_64
             app_label: Intel
@@ -101,7 +106,7 @@ jobs:
         run: |
           app="build/macos-app-${{ matrix.arch }}/HideMyEmail Generator.app"
           plist="$app/Contents/Info.plist"
-          version="${GITHUB_REF_NAME#v}"
+          version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml | head -1)"
 
           test -x "$app/Contents/Resources/hidemyemail"
           test -x "$app/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate"
@@ -142,8 +147,9 @@ jobs:
   # instead of provisioning two macOS runners for shell work.
   sign:
     needs: macos
+    if: github.ref_type == 'tag'
     environment: release
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -219,6 +225,7 @@ jobs:
 
   release:
     needs: [windows, sign]
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.1.1</string>
+	<string>2.1.0</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hidemyemail_generator"
-version = "2.1.1"
+version = "2.1.0"
 description = "Generate and manage iCloud Hide My Email addresses"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Follow-up to #66. That fix was necessary but not sufficient.

### What #66 got right, and what it missed
#66 made the build select Xcode 26 instead of the 16.4 default, and that worked — the run used `/Applications/Xcode_26.0.1.app` and the Swift build succeeded. But `actool` then crashed:

```
*** Terminating app due to uncaught exception 'IBPlatformToolFailureException',
    reason: 'The tool closed the connection (AssetCatalogAgent-AssetRuntime)'
```

Compiling an Icon Composer document needs the **macOS 26 runtime**, not just the Xcode 26 toolchain. The runners were macOS 15.7.7. Xcode 26 on macOS 15 can install, but its asset-catalog agent can't render Liquid Glass icons.

So the macOS jobs move to `macos-26` / `macos-26-intel`. Both labels exist, so the Intel build keeps a native runner — no cross-compilation, no dropped arch. The Xcode selection from #66 stays correct: `macos-26` defaults `/Applications/Xcode.app` to 26.5, which already passes the `>= 26` check (that was one of the six cases I tested there).

### Testing releases without burning versions
Three tagged attempts have now failed without publishing anything, which is a bad loop — each one costs a tag and produces no release.

`workflow_dispatch` lets the whole expensive path run from a branch. **Signing and publishing stay gated on `github.ref_type == 'tag'`**, so a test run:
- never touches `SPARKLE_PRIVATE_KEY`,
- never stalls on the `release` environment's required reviewer,
- never creates a GitHub Release,
- and never needs a version number.

What it *does* exercise is exactly what has been failing: `validate`, the Windows build, and both macOS builds including `actool` and the Swift tests.

The app-bundle check now reads the version from `pyproject.toml` rather than `${GITHUB_REF_NAME#v}`, since there's no tag name on a dispatch run. Equivalent on tag runs — `validate` already asserts the tag matches `pyproject.toml`.

### Version: 2.1.1 → 2.1.0
Neither 2.1.0 nor 2.1.1 was ever published; both tags were failed attempts. Versioning should describe the delta from the last release consumers actually received, 2.0.0 — and that delta is a native macOS app, an Android app, and new CLI commands. That's a minor release. Shipping it as 2.1.1 would imply users missed a 2.1.0 and that this is a patch on top of it.

`macos/Info.plist` moves with it, though the build script overwrites the plist from `pyproject.toml` anyway.

### Tag state
`v2.1.0` and `v2.1.1` have been deleted from the remote. Neither had a published release, and the Sparkle feed points at `releases/latest/download/`, which resolves to v2.0.0 — so no updater ever saw them. Every remaining tag now corresponds to a real release.

### Validation
`pytest -q` (23 passed) and `ruff check` pass. Workflow structure parsed and asserted: triggers, per-job `runs-on`, matrix runners, and the two `if` gates. The macOS build itself can't be run locally (this machine has only Command Line Tools) — the point of the `workflow_dispatch` change is that it no longer needs a tag to find out.