### PR TITLE
chore: sync uv.lock project version with pyproject 2.1.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -306,7 +306,7 @@ wheels = [
 
 [[package]]
 name = "hidemyemail-generator"
-version = "2.1.1"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
#67 changed `pyproject.toml` from 2.1.1 to 2.1.0 but missed `uv.lock`, which still recorded `version = "2.1.1"` for the root package.

Harmless to the v2.1.0 release — the shipped version comes from `pyproject.toml` and `Info.plist`, both correct, and the published artifacts are unaffected. `uv run --frozen` in CI passed because it validates dependency resolution rather than the root package version, which is why this wasn't caught.

Still worth correcting: #60 explicitly kept the locked project metadata synchronized with the package version, and a stale root version in the lockfile is confusing for anyone reading it.

One-line change, regenerated by `uv` rather than hand-edited.